### PR TITLE
Tests and audit of query option `table`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrodb",
-  "version": "0.9.47",
+  "version": "0.9.48",
   "description": "A library to more easily create and interact with multiple entities and heretical relationships in dynamodb",
   "main": "index.js",
   "scripts": {

--- a/src/clauses.js
+++ b/src/clauses.js
@@ -1,4 +1,5 @@
 const { QueryTypes, MethodTypes } = require("./types");
+const v = require("./validations");
 const e = require("./errors");
 
 function batchAction(action, type, entity, state, payload) {
@@ -357,6 +358,9 @@ let clauses = {
 	params: {
 		name: "params",
 		action(entity, state, options = {}) {
+			if (!v.isStringHasLength(options.table) && !v.isStringHasLength(entity._getTableName())) {
+				throw new e.ElectroError(e.ErrorCodes.MissingTable, `Table name not defined. Table names must be either defined on the model, instance configuration, or as a query option.`);
+			}
 			if (state.query.method === MethodTypes.query) {
 				return entity._queryParams(state, options);
 			} else if(state.query.method === MethodTypes.batchWrite) {

--- a/src/entity.js
+++ b/src/entity.js
@@ -464,7 +464,7 @@ class Entity {
 			if (option.pager) config.pager = true;
 			if (option.lastEvaluatedKeyRaw === true) config.lastEvaluatedKeyRaw = true;
 			if (option.limit) config.params.Limit = option.limit;
-			if (option.table) config.params.Limit = option.table;
+			if (option.table) config.params.TableName = option.table;
 			config.page = Object.assign({}, config.page, option.page);
 			config.params = Object.assign({}, config.params, option.params);
 			return config;
@@ -1479,7 +1479,11 @@ class Entity {
 			let index = indexes[accessPattern];
 			let indexName = index.index || "";
 			if (seenIndexes[indexName] !== undefined) {
-				throw new e.ElectroError(e.ErrorCodes.DuplicateIndexes, `Duplicate index defined in model: ${accessPattern} ${indexName || "(PRIMARY INDEX)"}`);
+				if (indexName === "") {
+					throw new e.ElectroError(e.ErrorCodes.DuplicateIndexes, `Duplicate index defined in model: ${accessPattern} ${indexName || "(PRIMARY INDEX)"}. This could be because you forgot to specify the index name of a secondary index defined in your model.`);
+				} else {
+					throw new e.ElectroError(e.ErrorCodes.DuplicateIndexes, `Duplicate index defined in model: ${accessPattern} ${indexName || "(PRIMARY INDEX)"}`);
+				}
 			}
 			seenIndexes[indexName] = indexName;
 			let hasSk = !!index.sk;
@@ -1685,9 +1689,6 @@ class Entity {
 				break;
 			default:
 				throw new Error("Invalid model");
-		}
-		if (typeof table !== "string" || table.length === 0) {
-			throw new e.ElectroError(e.ErrorCodes.InvalidConfig, `config.table must be string`);
 		}
 		/** end beta/v1 condition **/
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -115,6 +115,12 @@ const ErrorCodes = {
     name: "IncompleteFacets",
     sym: ErrorCode,
   },
+  MissingTable: {
+    code: 2003,
+    section: "missing-table",
+    name: "MissingTable",
+    sym: ErrorCode
+  },
   InvalidAttribute: {
     code: 3001,
     section: "invalid-attribute",

--- a/test/offline.entity.spec.js
+++ b/test/offline.entity.spec.js
@@ -2911,11 +2911,13 @@ describe("Entity", () => {
 			let params = entity.get(facets).params();
 			expect(params.TableName).to.equal(table);
 		});
-		it("should not allow the table to be undefined", () => {
+		it("should allow the table to be defined in query options", () => {
 			let model = {
-				service: "myservice",
-				entity: "myentity",
-				version: "1",
+				model: {
+					service: "myservice",
+					entity: "myentity",
+					version: "1",
+				},
 				attributes: {
 					id: "string",
 					org: "string",
@@ -2935,7 +2937,42 @@ describe("Entity", () => {
 					}
 				}
 			};
-			expect(() => new Entity(model)).to.throw("config.table must be string");
+			let table = "electro";
+			let facets = {type: "abc", org: "def", id: "hij"};
+			let entity = new Entity(model);
+			let params = entity.get(facets).params({table});
+			console.log(params);
+			expect(params.TableName).to.equal(table);
+		});
+		it("should not allow the table to be undefined", () => {
+			let model = {
+				model: {
+					service: "myservice",
+					entity: "myentity",
+					version: "1",
+				},
+				attributes: {
+					id: "string",
+					org: "string",
+					type: "string"
+				},
+				indexes: {
+					thing: {
+						collection: "things",
+						pk: {
+							field: "pk",
+							facets: ["type", "org"]
+						},
+						sk: {
+							field: "sk",
+							facets: ["id"]
+						}
+					}
+				}
+			};
+			let entity = new Entity(model);
+			let facets = {type: "abc", org: "def", id: "hij"};
+			expect(() => entity.get(facets).params()).to.throw("Table name not defined. Table names must be either defined on the model, instance configuration, or as a query option.");
 		});
 	});
 	describe("key prefixes", () => {
@@ -3263,7 +3300,7 @@ describe("Entity", () => {
 					}
 				}
 			};
-			expect(() => new Entity(schema)).to.throw("Duplicate index defined in model: index2 (PRIMARY INDEX) - For more detail on this error reference: https://github.com/tywalch/electrodb#duplicate-indexes")
+			expect(() => new Entity(schema)).to.throw("Duplicate index defined in model: index2 (PRIMARY INDEX). This could be because you forgot to specify the index name of a secondary index defined in your model. - For more detail on this error reference: https://github.com/tywalch/electrodb#duplicate-indexes")
 		});
 		it("Should check for index and collection name overlap", () => {
 			let schema = {

--- a/test/offline.options.spec.js
+++ b/test/offline.options.spec.js
@@ -1,0 +1,190 @@
+const {expect} = require("chai");
+const {Entity} = require("../src/entity");
+
+describe("Query Options", () => {
+   describe("table", () => {
+       let schema = {
+           model: {
+               entity: "queryoptions",
+               service: "tests",
+               version: "1"
+           },
+           attributes: {
+               prop1: "string",
+               prop2: "string",
+               prop3: "string",
+               prop4: "string",
+               prop5: "string"
+           },
+           indexes: {
+               index1: {
+                   pk: {
+                       field: "pk",
+                       facets: ["prop1"]
+                   },
+                   sk: {
+                       field: "sk",
+                       facets: ["prop2"]
+                   }
+               },
+               index2: {
+                   index: "gsi1",
+                   pk: {
+                       field: "gsi1pk",
+                       facets: ["prop3"]
+                   },
+                   sk: {
+                       field: "gsi1sk",
+                       facets: ["prop4"]
+                   }
+               }
+           }
+       };
+       let entity = new Entity(schema, {table: "should_be_overwritten"});
+       let properties = {
+           prop1: "prop1Value",
+           prop2: "prop2Value",
+           prop3: "prop3Value",
+           prop4: "prop4Value",
+           prop5: "prop5Value"
+       };
+       let {prop1, prop2, prop3, prop4, prop5} = properties;
+       let table = "table_override";
+       let tests = [
+           // CRUD
+           {
+               name: "get",
+               query: () => entity.get(properties).params({table}),
+               extract: (params) => params.TableName
+           },
+           {
+               name: "delete",
+               query: () => entity.delete(properties).params({table}),
+               extract: (params) => params.TableName
+           },
+           {
+               name: "scan",
+               query: () => entity.scan.params({table}),
+               extract: (params) => params.TableName
+           },
+           {
+               name: "put",
+               query: () => entity.put(properties).params({table}),
+               extract: (params) => params.TableName
+           },
+           {
+               name: "create",
+               query: () => entity.create(properties).params({table}),
+               extract: (params) => params.TableName
+           },
+           {
+               name: "update",
+               query: () => entity.update(properties).set({prop5}).params({table}),
+               extract: (params) => params.TableName
+           },
+           {
+               name: "patch",
+               query: () => entity.patch(properties).set({prop5}).params({table}),
+               extract: (params) => params.TableName
+           },
+
+           // Batch CRUD
+           {
+               name: "batchGet",
+               query: () => entity.get([properties]).params({table}),
+               extract: (params) => Object.keys(params.RequestItems)[0]
+           },
+           {
+               name: "batchDelete",
+               query: () => entity.delete([properties]).params({table}),
+               extract: (params) => Object.keys(params.RequestItems)[0]
+           },
+           {
+               name: "batchPut",
+               query: () => entity.put([properties]).params({table}),
+               extract: (params) => Object.keys(params.RequestItems)[0]
+           },
+
+           // Queries (index1)
+           {
+               name: "query",
+               query: () => entity.query.index1(properties).params({table}),
+               extract: (params) => params.TableName
+           },
+           {
+               name: "begins",
+               query: () => entity.query.index1({prop1}).begins({prop2}).params({table}),
+               extract: (params) => params.TableName
+           },
+           {
+               name: "between",
+               query: () => entity.query.index1({prop1}).between({prop2}, {prop2}).params({table}),
+               extract: (params) => params.TableName
+           },
+           {
+               name: "gte",
+               query: () => entity.query.index1({prop1}).gte({prop2}).params({table}),
+               extract: (params) => params.TableName
+           },
+           {
+               name: "gt",
+               query: () => entity.query.index1({prop1}).gt({prop2}).params({table}),
+               extract: (params) => params.TableName
+           },
+           {
+               name: "lt",
+               query: () => entity.query.index1({prop1}).lt({prop2}).params({table}),
+               extract: (params) => params.TableName
+           },
+           {
+               name: "lte",
+               query: () => entity.query.index1({prop1}).lte({prop2}).params({table}),
+               extract: (params) => params.TableName
+           },
+
+           // Queries (index2)
+           {
+               name: "query",
+               query: () => entity.query.index2(properties).params({table}),
+               extract: (params) => params.TableName
+           },
+           {
+               name: "begins",
+               query: () => entity.query.index2({prop3}).begins({prop4}).params({table}),
+               extract: (params) => params.TableName
+           },
+           {
+               name: "between",
+               query: () => entity.query.index2({prop3}).between({prop4}, {prop4}).params({table}),
+               extract: (params) => params.TableName
+           },
+           {
+               name: "gte",
+               query: () => entity.query.index2({prop3}).gte({prop4}).params({table}),
+               extract: (params) => params.TableName
+           },
+           {
+               name: "gt",
+               query: () => entity.query.index2({prop3}).gt({prop4}).params({table}),
+               extract: (params) => params.TableName
+           },
+           {
+               name: "lt",
+               query: () => entity.query.index2({prop3}).lt({prop4}).params({table}),
+               extract: (params) => params.TableName
+           },
+           {
+               name: "lte",
+               query: () => entity.query.index2({prop3}).lte({prop4}).params({table}),
+               extract: (params) => params.TableName
+           }
+       ];
+       for (let test of tests) {
+           it(`Should overwrite table used for a ${test.name} query/operation`, () => {
+                let params = test.query();
+                let tableName = test.extract(params);
+                expect(table).to.equal(tableName);
+           });
+       }
+   });
+});


### PR DESCRIPTION
The query option `table` was not consistently applied across all queries.