### PR TITLE
Query exception handling to originate only when `finisher` methods are called (`go`, `params`, `page`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "electrodb",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrodb",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "A library to more easily create and interact with multiple entities and heretical relationships in dynamodb",
   "main": "index.js",
   "scripts": {

--- a/src/entity.js
+++ b/src/entity.js
@@ -61,7 +61,7 @@ class Entity {
 			return this._makeChain("", this._clausesWithFilters, clauses.index).scan().filter(attr => {
 				let eqFilters = [];
 				for (let facet of Object.keys(facets)) {
-					if (attr[facet]) {
+					if (attr[facet] !== undefined && facets[facet] !== undefined) {
 						eqFilters.push(attr[facet].eq(facets[facet]));
 					}
 				}
@@ -73,7 +73,7 @@ class Entity {
 			).filter(attr => {
 				let eqFilters = [];
 				for (let facet of Object.keys(facets)) {
-					if (attr[facet]) {
+					if (attr[facet] !== undefined && facets[facet] !== undefined) {
 						eqFilters.push(attr[facet].eq(facets[facet]));
 					}
 				}

--- a/src/entity.js
+++ b/src/entity.js
@@ -329,13 +329,15 @@ class Entity {
 		try {
 			let results;
 
-			if (config.raw) {
+			if (config.raw && !config.pager) {
 				if (response.TableName) {
 					// a VERY hacky way to deal with PUTs
 					results = {};
 				} else {
 					results = response;
 				}
+			} else if (config.raw && config.pager) {
+				return [response.LastEvaluatedKey || null, response];
 			} else {
 				let data = {};
 				if (response.Item) {
@@ -358,7 +360,7 @@ class Entity {
 
 			if (config.pager) {
 				let nextPage = response.LastEvaluatedKey || null;
-				if (!config.raw && !config.lastEvaluatedKeyRaw) {
+				if (!config.lastEvaluatedKeyRaw) {
 					nextPage = this._formatReturnPager(index, nextPage, results[results.length - 1]);
 				}
 				results = [nextPage, results];
@@ -1399,7 +1401,7 @@ class Entity {
 	}
 
 	_getCollectionSk(collection) {
-		if (typeof collection && collection.length) {
+		if (typeof collection === "string" && collection.length) {
 			return `$${collection}`.toLowerCase();
 		} else {
 			return "";

--- a/src/filters.js
+++ b/src/filters.js
@@ -139,15 +139,31 @@ class FilterFactory {
 		return attributes;
 	}
 
+	_cleanUpExpression(value) {
+		if (typeof value === "string" && value.length > 0) {
+			return value.replace(/\n|\r/g, "").trim();
+		}
+		return ""
+	}
+
+	_isEmptyExpression(value) {
+		if (typeof value !== "string") {
+			throw new Error("Invalid expression value type. Expected type string.");
+		}
+		return !value.replace(/\n|\r|\w/g, "").trim();
+	}
+
 	_concatFilterExpression(existingExpression = "", newExpression = "") {
 		if (typeof existingExpression === "string" && existingExpression.length) {
-			existingExpression = existingExpression.replace(/\n|\r/g, "").trim();
-			newExpression = newExpression.replace(/\n|\r/g, "").trim();
+			existingExpression = this._cleanUpExpression(existingExpression);
+			newExpression = this._cleanUpExpression(newExpression);
+			let isEmpty = this._isEmptyExpression(newExpression);
+			if (isEmpty) {
+				return existingExpression;
+			}
 			let existingNeedsParens =
 				!existingExpression.startsWith("(") &&
 				!existingExpression.endsWith(")");
-			let newNeedsParens =
-				!newExpression.startsWith("(") && !newExpression.endsWith(")");
 			if (existingNeedsParens) {
 				existingExpression = `(${existingExpression})`;
 			}

--- a/src/where.js
+++ b/src/where.js
@@ -72,10 +72,28 @@ class WhereFactory {
     return operations;
   }
 
+  _cleanUpExpression(value) {
+  	if (typeof value === "string" && value.length > 0) {
+  		return value.replace(/\n|\r/g, "").trim();
+	}
+  	return ""
+  }
+
+  _isEmptyExpression(value) {
+	  if (typeof value !== "string") {
+		  throw new Error("Invalid expression value type. Expected type string.");
+	  }
+	  return !value.replace(/\n|\r|\w/g, "").trim();
+  }
+
   _concatFilterExpression(existingExpression = "", newExpression = "") {
-		if (typeof existingExpression === "string" && existingExpression.length) {
-			existingExpression = existingExpression.replace(/\n|\r/g, "").trim();
-			newExpression = newExpression.replace(/\n|\r/g, "").trim();
+		if (typeof existingExpression === "string" && existingExpression.length > 0) {
+			existingExpression = this._cleanUpExpression(existingExpression);
+			newExpression = this._cleanUpExpression(newExpression);
+			let isEmpty = this._isEmptyExpression(newExpression);
+			if (isEmpty) {
+				return existingExpression;
+			}
 			let existingNeedsParens = !existingExpression.startsWith("(") && !existingExpression.endsWith(")");
 			if (existingNeedsParens) {
 				existingExpression = `(${existingExpression})`;

--- a/test/connected.page.spec.js
+++ b/test/connected.page.spec.js
@@ -292,12 +292,12 @@ describe("Page", async () => {
 
     for (let test of tests) {
       let query = test.type === "scan"
-        ? () => tasks.scan.page(test.input.page)
-        : () => tasks.query[test.input.index](test.input.facets).page(test.input.page);
+          ? () => tasks.scan.page(test.input.page)
+          : () => tasks.query[test.input.index](test.input.facets).page(test.input.page);
       try {
-        await query()
-      } catch(err) {
-        expect(err.message).to.be.equal(test.output.error);
+        await query();
+      } catch (err) {
+          expect(err.message).to.be.equal(test.output.error);
       }
     }
   }).timeout(10000);
@@ -326,10 +326,15 @@ describe("Page", async () => {
     }
   }).timeout(10000);
 
-  it("Should require a dynamodb client object to use the page method", () => {
+  it("Should require a dynamodb client object to use the page method", async () => {
     let tasks = new Tasks(TasksModel);
-    let query = () => tasks.query.task({task: "abc"}).page();
-    expect(query).to.throw("No client defined on model")
+    let {success, results} = await tasks.query
+        .task({task: "abc"})
+        .page()
+        .then(results => ({success: true, results}))
+        .catch(results => ({success: false, results}));
+    expect(success).to.be.false;
+    expect(results.message).to.be.equal("No client defined on model - For more detail on this error reference: https://github.com/tywalch/electrodb#no-client-defined-on-model")
   });
 
 

--- a/test/connected.page.spec.js
+++ b/test/connected.page.spec.js
@@ -5,6 +5,7 @@ const {expect} = require("chai");
 const {Entity} = require("../");
 const endpoint = process.env.LOCAL_DYNAMO_ENDPOINT;
 const region = "us-east-1";
+const isLocal = endpoint !== undefined;
 AWS.config.update({region, endpoint});
 const client = new AWS.DynamoDB.DocumentClient();
 const sleep = async (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -201,7 +202,7 @@ Tasks.points = [1, 2, 3, 5, 8, 13, 21, 50, 100];
 Tasks.sentences = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum condimentum eros ut auctor cursus. Vivamus ac malesuada purus. Phasellus scelerisque tellus non nisi tempus, eget sagittis metus tempus. Mauris eu sapien non magna vulputate lobortis. Maecenas posuere enim et dolor ultrices, et tempus ligula scelerisque. Mauris vehicula turpis nec mi blandit convallis. Curabitur lacinia quis eros in blandit. Aliquam sed mauris auctor, tincidunt risus sed, fringilla turpis. Vestibulum molestie nec mauris vel sollicitudin. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Integer vitae orci sem. Vivamus finibus molestie lectus vel tempus. Curabitur rutrum, mauris sit amet blandit imperdiet, nibh purus molestie diam, sit amet maximus odio quam lacinia nisi. Proin laoreet dictum auctor. Mauris placerat commodo nisl in condimentum. Pellentesque non magna diam. Quisque in varius metus. Aenean lorem tellus, gravida nec egestas eu, rutrum id lectus. Ut id lacus leo. Donec dignissim id eros vitae auctor. Nunc tincidunt diam id fermentum placerat. Aliquam efficitur felis metus, id tincidunt lacus tincidunt a. Aliquam erat volutpat. Integer nec quam at metus suscipit viverra. Pellentesque non imperdiet est. Proin suscipit justo ex, eget condimentum leo imperdiet ac. Fusce efficitur purus a convallis euismod. Integer eget nibh erat. Mauris id venenatis urna. Nullam orci lorem, sollicitudin sit amet sapien ornare, euismod lacinia lacus. Aenean vel eros sagittis, dignissim orci et, posuere nunc. Maecenas vel est elit. Nam ac dui nec justo aliquet volutpat vel eget risus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Integer eu nisl purus. Vestibulum finibus lorem euismod, facilisis ex quis, commodo enim. Nullam placerat lobortis lacus, vitae blandit risus gravida in. Duis quis ultricies orci, non rhoncus ligula. Praesent rhoncus urna sed aliquam sodales. Nunc blandit ut quam id porta. Aliquam erat volutpat. Morbi ultrices ornare ante id dictum. Suspendisse potenti. Quisque interdum imperdiet erat. Interdum et malesuada fames ac ante ipsum primis in faucibus. Vestibulum tincidunt erat quis vestibulum venenatis. Cras vel convallis urna. Proin imperdiet odio nisi, et euismod tortor porttitor at. Pellentesque pharetra mi sed quam cursus viverra. Pellentesque tellus nisi, placerat sed nibh iaculis, viverra rutrum ligula. Fusce condimentum scelerisque lorem non efficitur. Suspendisse ac malesuada lectus. Etiam id cursus orci, ut sollicitudin augue. Morbi et metus dapibus, feugiat risus et, accumsan ligula. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Proin sodales et nibh at lacinia. Morbi velit tellus, ultricies ac venenatis ac, dignissim eu neque. Quisque placerat magna eget nibh porttitor, a ultricies turpis pellentesque. Phasellus fringilla egestas erat, id interdum sem imperdiet et. Duis diam lorem, feugiat at lacinia sit amet, elementum at libero. Sed vehicula eu velit ut porta. Phasellus ac fermentum urna, a viverra justo. Aliquam vel mi et libero suscipit finibus ut vel purus. Aenean id leo ut felis sollicitudin finibus id sed urna. Donec et purus purus. Morbi euismod condimentum augue, et hendrerit justo elementum et. Nulla dictum et mauris id hendrerit. Aenean non dolor lobortis, convallis metus quis, euismod felis. Curabitur et pretium nunc, a accumsan enim. Donec tempor orci vel pharetra commodo. Mauris sit amet metus porttitor, porttitor ipsum non, aliquet sapien. Proin eu pharetra dolor, sed ultricies arcu. Donec venenatis elementum nisl at varius. Ut sed scelerisque risus. Vestibulum quis leo non sapien eleifend auctor id consequat velit. Maecenas porta felis vitae velit dictum elementum. Vivamus rutrum sodales cursus. Nullam eros ante, fermentum nec nunc non, bibendum iaculis dui. Mauris enim justo, feugiat vitae massa eget, lobortis iaculis purus. Suspendisse tellus nibh, semper vitae purus sed, luctus cursus turpis. Donec id vehicula odio. Nunc non diam ac est vestibulum mattis. Phasellus mattis ipsum eu condimentum convallis. Vivamus tempor massa eu ullamcorper condimentum. Nam ultricies in mauris sit amet pellentesque. Suspendisse dui lectus, pellentesque in volutpat nec, consectetur vitae mi. Duis mi libero, laoreet at turpis vitae, rutrum commodo nulla. Maecenas viverra arcu in elit aliquet malesuada. Integer diam erat, egestas et nulla a, gravida condimentum massa. Nulla malesuada ex ut cursus viverra. In commodo lacinia libero, ac elementum lectus maximus ut. Donec eget lorem quis mi suscipit sagittis. Nunc placerat odio quis mauris iaculis, maximus rutrum est tempor. Integer sollicitudin ipsum urna, at malesuada diam accumsan quis. Praesent eu eleifend urna. Pellentesque molestie diam sit amet tristique condimentum. Aliquam fringilla et nisi vel fermentum. Vivamus elit leo, maximus in dolor ac, vestibulum commodo mi. Ut id nisi nec massa faucibus vulputate sit amet nec ligula. Integer sapien purus, bibendum in sollicitudin a, mollis a purus. Donec quis libero nisl. Mauris blandit ipsum nibh, at ultricies sapien volutpat quis. Integer nec leo efficitur, posuere nisi sed, placerat ante. Nullam malesuada nec tellus eu condimentum. Vestibulum porttitor fermentum dui, vel efficitur neque rhoncus vel. Maecenas sollicitudin gravida leo non mattis. Morbi vehicula mauris eu sagittis ullamcorper. Nam pellentesque molestie consectetur. Vivamus finibus enim justo, eu lacinia arcu iaculis et. Nullam iaculis diam sit amet velit varius, egestas rhoncus nulla venenatis. Duis at eros nibh. Sed sit amet finibus arcu. Aliquam venenatis felis sit amet odio blandit, ut faucibus tellus volutpat. Integer sit amet leo neque. Nullam ullamcorper ullamcorper turpis, vitae feugiat eros varius egestas. Morbi varius luctus augue, quis egestas eros fermentum vel. Nam semper tincidunt ornare. Sed at blandit justo, nec volutpat erat. Vivamus consequat, sapien at laoreet vulputate, urna ante pharetra libero, at faucibus lacus nunc sit amet turpis. Cras luctus diam sit amet bibendum fringilla. Nullam at erat a metus consectetur congue. Nulla accumsan nisl ac lacus vulputate iaculis. Sed interdum aliquet ligula, sit amet rutrum nisi aliquam et. Etiam faucibus at erat nec congue. Integer sed sapien ac lacus finibus pellentesque. Sed convallis erat enim, eget mattis tellus tincidunt ac. Cras nec ultricies purus, sed vestibulum est. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vivamus sit amet nulla quis odio feugiat venenatis. Proin quis elit ante. Vestibulum nec magna quis magna bibendum dignissim. Morbi venenatis ligula et enim semper tincidunt. In hac habitasse platea dictumst. Nulla sodales arcu eu ipsum imperdiet suscipit id sed augue. Pellentesque accumsan diam purus, sed elementum orci consequat quis. Sed nec dolor quis turpis finibus fermentum. Donec imperdiet elementum leo varius fermentum. Maecenas vitae euismod leo, a euismod nunc. Interdum et malesuada fames ac ante ipsum primis in faucibus. Pellentesque sit amet enim et libero eleifend eleifend. Quisque efficitur neque nulla, quis lobortis orci tempor et. Duis non viverra ligula. Sed elementum, ex sit amet molestie lobortis, sapien diam condimentum tortor, nec mollis mi odio ac lacus. Mauris non augue turpis. Cras venenatis faucibus augue sit amet vulputate. Pellentesque sit amet tempus nisl. Aenean ultrices neque nec ipsum malesuada tincidunt. Pellentesque iaculis mauris magna, ut ornare nulla congue sed. Nullam quis convallis leo. Donec bibendum a arcu pharetra dictum. Sed varius commodo lectus eu bibendum. Vivamus vel condimentum ligula, nec pharetra nunc. Suspendisse malesuada est in eros accumsan, nec tempus diam lacinia. Integer vel dui in ante tempor pharetra in id magna. Aliquam erat volutpat. Cras ligula est, fringilla quis egestas a, ornare at nisi. Integer cursus imperdiet libero ut eleifend. Donec mollis arcu eu lacus euismod egestas. Sed a arcu nec turpis vestibulum porta eu nec elit. Vivamus id tellus vitae lacus euismod vehicula in eget purus. Suspendisse potenti. Praesent vel lectus pulvinar, feugiat urna eu, sodales lacus. Ut sed leo in nisl vestibulum bibendum eget id velit. Donec efficitur lacus ut commodo gravida. Duis placerat, turpis eget placerat pulvinar, nisi est ultricies velit, in ullamcorper lorem odio vel lorem. Cras velit velit, cursus imperdiet suscipit sed, pretium quis purus. Cras neque est, sodales nec congue in, faucibus eget magna. Nulla feugiat, massa at blandit lacinia, tellus dui suscipit velit, id eleifend lacus diam at orci. Donec sit amet ultrices nulla. Maecenas quis sapien a libero laoreet ultrices. Curabitur et ullamcorper elit. Phasellus faucibus volutpat orci. Curabitur suscipit mattis aliquet. Etiam vehicula varius ante, sed blandit leo mattis quis. Donec eu sapien cursus lacus tempor ultricies. Proin fermentum diam id ligula aliquam varius. Vestibulum ac finibus sapien. Donec ultricies eros vel tellus porttitor cursus. Morbi auctor ipsum metus, sed malesuada orci convallis vel. Vestibulum quis leo eget quam malesuada faucibus ac eu erat. Praesent arcu eros, pulvinar non ante id, luctus sodales risus. In non arcu eget justo rutrum tempus vel sit amet nulla. Maecenas eu diam nisl. Phasellus vitae felis vehicula, pulvinar enim nec, pulvinar felis. Nullam ac justo dui. Nam lectus nibh, porttitor in lacus sit amet, hendrerit maximus orci. Integer scelerisque massa porttitor felis ultrices accumsan. Duis rhoncus lectus ut risus suscipit placerat. Morbi tristique egestas mi ac accumsan. Proin vulputate tempor dui quis congue. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nullam nisl ipsum, lacinia id interdum non, venenatis vel nisl. Maecenas tincidunt urna nisl, id ullamcorper ipsum placerat et. Etiam congue lacus vel justo aliquam, id sollicitudin turpis tempor. Phasellus vehicula arcu sed risus hendrerit interdum. Vivamus sit amet risus lobortis, egestas diam non, placerat tellus. In vitae diam augue. In blandit, metus sed pharetra mattis, mauris nulla consectetur eros, sit amet cursus metus mauris nec lacus. Vivamus suscipit ac elit a ultricies. Aenean accumsan sapien at lectus cursus eleifend. Sed iaculis non metus sit amet lacinia. Aliquam id sapien a sapien vehicula tincidunt. Aenean maximus venenatis nunc et lobortis. Aliquam tristique auctor sapien a sagittis. Curabitur congue tellus turpis, at lacinia ex tincidunt ultrices. Phasellus ornare vel enim non tincidunt. Sed quis odio viverra, scelerisque est a, efficitur quam. Suspendisse dictum ultricies risus, id venenatis dui pulvinar et. Pellentesque gravida ligula nisi, et elementum magna egestas ac. Sed ornare est in interdum pretium. Proin sit amet tincidunt neque. Phasellus ac lacus vitae libero finibus eleifend quis et turpis. Nullam accumsan semper tortor non ultricies. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Quisque semper urna id ligula placerat, in aliquet velit dapibus. Proin in velit velit. Donec mattis felis eros, pharetra facilisis nisl tristique vel. Praesent cursus rhoncus accumsan. Nullam egestas bibendum elit, at finibus metus sodales id. Nulla facilisi. Nam euismod sem arcu, nec vulputate dui blandit et. Integer pellentesque a velit ornare volutpat. In facilisis sodales risus a imperdiet. Vestibulum bibendum, dui et mollis dictum, quam tortor consectetur augue, id accumsan tortor arcu vitae eros. Etiam et libero tortor. Ut at nisl vitae mi iaculis convallis. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Mauris eleifend pellentesque fringilla. Mauris vel risus justo. Mauris sed molestie lacus. Mauris sagittis id arcu a fringilla. Cras eget neque sed lorem venenatis mollis non vel mi. Aenean feugiat sem non volutpat malesuada. Sed enim mi, rhoncus a imperdiet eget, feugiat cursus nisl. Donec ut auctor nibh. Mauris vitae tempor ligula, eget sagittis lacus. Sed vitae aliquet nisi. Sed porttitor ullamcorper orci, eget volutpat sem consectetur in. Nam pretium egestas pretium. Etiam eu mattis est. Ut pulvinar lectus sit amet lectus venenatis laoreet. Nullam lectus quam, scelerisque id laoreet ut, elementum et dolor. Etiam imperdiet eu magna id ornare. Ut blandit tristique tellus. Proin feugiat dolor sit amet fermentum dignissim. Vestibulum aliquam vestibulum fermentum. Nulla auctor, dolor porta hendrerit efficitur, ex turpis facilisis diam, a sollicitudin nulla ante eu risus. Nulla iaculis, mi a mattis sollicitudin, nibh lorem rhoncus felis, vel vestibulum lacus leo ut turpis. Nullam eget ipsum id metus elementum tristique non ac mi. Praesent ut pulvinar eros. Aenean id purus ipsum. In auctor tellus quis lacus imperdiet vehicula. Duis volutpat sodales maximus. Suspendisse placerat tellus tortor. Aenean bibendum erat quis enim faucibus finibus. Aenean urna risus, dapibus ac pellentesque vitae, gravida quis nibh. Ut dui augue, suscipit et purus vel, tristique condimentum dolor. Donec vestibulum iaculis posuere. Maecenas congue nulla sed faucibus porta. Proin in feugiat nisl.`.split(".")
 
 describe("Page", async () => {
-  const total = 20;
+  const total = isLocal ? 500 : 20;
   const tasks = new Tasks(TasksModel, {client});
 
   before(async function() {
@@ -255,6 +256,80 @@ describe("Page", async () => {
       let results = await tasks.paginate(2, total, query, testPage);
       expect(() => Tasks.compareTasks(results, loaded)).to.not.throw;
     }
+  }).timeout(10000);
+
+  it("Paginate without overlapping values", async () => {
+    let limit = 30;
+    let count = 0;
+    let page = null;
+    let all = [];
+    let keys = new Set();
+    do {
+      count++;
+      let [next, items] = await tasks.query.assigned({employee: Tasks.employees[0]}).page(page, {limit});
+      if (next && count > 0) {
+        expect(next).to.have.keys(["project", "points", "employee", "task"]);
+      }
+      expect(items.length <= limit).to.be.true;
+      for (let item of items) {
+        keys.add(item.task + item.project + item.employee);
+        all.push(item);
+      }
+      page = next;
+    } while(page !== null);
+    expect(all).to.have.length(keys.size);
+  }).timeout(10000);
+
+  it("Paginate without overlapping values with raw response", async () => {
+    let limit = 30;
+    let count = 0;
+    let page = null;
+    let all = [];
+
+    do {
+      count++;
+      let keys = new Set();
+      let [next, results] = await tasks.query.projects({project: Tasks.projects[0]}).page(page, {limit, raw: true});
+      if (next !== null && count > 1) {
+        expect(next).to.have.keys(["sk", "pk", "gsi1sk", "gsi1pk"]);
+      }
+      expect(results.Items.length <= limit).to.be.true;
+      for (let item of results.Items) {
+        keys.add(item.pk + item.sk);
+        all.push(item);
+      }
+      if (results.Items.length !== keys.size) {
+        console.log({items: results.Items, keys});
+      }
+      expect(results.Items.length).to.equal(keys.size);
+      page = next;
+    } while(page !== null);
+  }).timeout(10000);
+
+  it("Paginate without overlapping values with lastEvaluatedKeyRaw enabled", async () => {
+    let limit = 30;
+    let count = 0;
+    let page = null;
+    let all = [];
+
+    do {
+      count++;
+      let keys = new Set();
+      let [next, items] = await tasks.query.projects({project: Tasks.projects[0]}).page(page, {limit, lastEvaluatedKeyRaw: true});
+      if (next !== null && count > 1) {
+        expect(next).to.have.keys(["sk", "pk", "gsi1sk", "gsi1pk"]);
+      }
+      expect(items.length <= limit).to.be.true;
+      for (let item of items) {
+        keys.add(item.task + item.project + item.employee);
+        all.push(item);
+      }
+      if (items.length !== keys.size) {
+        console.log({items: items, keys});
+      }
+      expect(items.length).to.equal(keys.size);
+      page = next;
+    } while(page !== null);
   }).timeout(10000);
 
   it("Should not accept incomplete page facets", async () => {

--- a/test/offline.entity.spec.js
+++ b/test/offline.entity.spec.js
@@ -2508,6 +2508,27 @@ describe("Entity", () => {
 			expect(keys).to.be.deep.equal([]);
 			expect(index).to.be.equal("");
 		});
+		it("Should decide to scan and not add undefined values to the query filters", () => {
+			let { index, keys, shouldScan} = MallStores._findBestIndexKeyMatch({ leaseEnd });
+			let mallId = undefined;
+			let params = MallStores.find({leaseEnd, mallId})
+				.where(() => "")
+				.params();
+			expect(params).to.be.deep.equal({
+				TableName: 'StoreDirectory',
+				ExpressionAttributeNames: { "#__edb_e__": "__edb_e__", "#__edb_v__": "__edb_v__", '#leaseEnd': 'leaseEnd', '#pk': 'pk' },
+				ExpressionAttributeValues: {
+					":__edb_e__": "MallStores",
+					":__edb_v__": "1",
+					':leaseEnd1': '123',
+					':pk': '$mallstoredirectory_1$mallstores#id_'
+				},
+				FilterExpression: "begins_with(#pk, :pk) AND #__edb_e__ = :__edb_e__ AND #__edb_v__ = :__edb_v__ AND #leaseEnd = :leaseEnd1"
+			});
+			expect(shouldScan).to.be.true;
+			expect(keys).to.be.deep.equal([]);
+			expect(index).to.be.equal("");
+		});
 		it("Should match on the primary index", () => {
 			let { index, keys } = MallStores._findBestIndexKeyMatch({ id });
 			let params = MallStores.find({id}).params();

--- a/test/offline.entity.spec.js
+++ b/test/offline.entity.spec.js
@@ -3319,6 +3319,62 @@ describe("Entity", () => {
 			};
 			expect(() => new Entity(schema)).to.throw("Duplicate index defined in model found in Access Pattern 'index2': '(PRIMARY INDEX)'. This could be because you forgot to specify the index name of a secondary index defined in your model. - For more detail on this error reference: https://github.com/tywalch/electrodb#duplicate-indexes")
 		});
+		it("Should check for duplicate indexes on secondary index", () => {
+			let schema = {
+				model: {
+					entity: "MyEntity",
+					service: "MyService",
+					version: "1"
+				},
+				table: "MyTable",
+				attributes: {
+					prop1: {
+						type: "string",
+					},
+					prop2: {
+						type: "string"
+					},
+					prop3: {
+						type: "string"
+					}
+				},
+				indexes: {
+					index1: {
+						pk: {
+							field: "pk",
+							facets: ["prop1"],
+						},
+						sk: {
+							field: "sk",
+							facets: ["prop2", "prop3"],
+						},
+					},
+					index2: {
+						index: "gsi1",
+						pk: {
+							field: "gsi1pk",
+							facets: ["prop3"],
+						},
+						sk: {
+							field: "gsi1sk",
+							facets: ["prop2", "prop1"],
+						},
+					},
+					index3: {
+						index: "gsi1",
+						pk: {
+							field: "gsi2pk",
+							facets: ["prop3"],
+						},
+						sk: {
+							field: "gsi2sk",
+							facets: ["prop2", "prop1"],
+						},
+					}
+				}
+			};
+			expect(() => new Entity(schema)).to.throw("Duplicate index defined in model found in Access Pattern 'index3': 'gsi1' - For more detail on this error reference: https://github.com/tywalch/electrodb#duplicate-indexes")
+		});
 		it("Should check for index and collection name overlap", () => {
 			let schema = {
 				model: {

--- a/test/offline.filters.spec.js
+++ b/test/offline.filters.spec.js
@@ -117,6 +117,23 @@ let model = {
 };
 
 describe("Filter", () => {
+	it("Should allow for a filter to return an empty string", () => {
+		let MallStores = new Entity(model);
+
+		let params = MallStores.find({id: "abc"})
+			.filter(() => "")
+			.filter(() => "")
+			.filter(() => "")
+			.params()
+
+		expect(params).to.deep.equal({
+			KeyConditionExpression: '#pk = :pk',
+			TableName: 'StoreDirectory',
+			ExpressionAttributeNames: { '#id': 'storeLocationId', '#pk': 'pk' },
+			ExpressionAttributeValues: { ':id1': 'abc', ':pk': '$mallstoredirectory_1$mallstores#id_abc' },
+			FilterExpression: '#id = :id1'
+		});
+	})
 	describe("Clause Building", () => {
 		let MallStores = new Entity(model);
 		it("Should build a clause", () => {

--- a/test/offline.where.spec.js
+++ b/test/offline.where.spec.js
@@ -65,6 +65,21 @@ let animals = [
 ];
 
 describe("Offline Where", () => {
+    it("Should allow where clauses to return empty strings", () => {
+        let animals = WhereTests.query
+            .farm({pen})
+            .where(() => "")
+            .where(() => "")
+            .where(() => "")
+            .params();
+
+        expect(animals).to.deep.equal({
+            KeyConditionExpression: '#pk = :pk and begins_with(#sk1, :sk1)',
+            TableName: 'electro',
+            ExpressionAttributeNames: { '#pk': 'pk', '#sk1': 'sk' },
+            ExpressionAttributeValues: { ':pk': '$tests#pen_pen_name', ':sk1': '$filters_1#row_' }
+        });
+    })
     it("Should filter 'eq' with 'where'", () => {
         let animals = WhereTests.query
             .farm({pen})


### PR DESCRIPTION
This change improves query error handling to throw exceptions only when a finisher method is called. Currently some errors will throw while building the query which can result in requiring users to double up on their exception handling in the event they are using `go` or `page` which should `reject` not `throw`