### PR TITLE
ElectroDB took into consideration whether or not a joined entity had …

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,11 +312,12 @@ When joining a Model/Entity to a Service, ElectroDB will perform a number of val
 
 - [Entity](#entities) names must be unique across a Service.
 - [Collection](#collections) names must be unique across a Service.
+- All [Collections](#collections) map to on the same DynamoDB indexes with the same index field names. See [Indexes](#indexes).
+- Partition Key [Facets](#facet-arrays) on a [Collection](#collections) must have the same attribute names and labels (if applicable). See [Attribute Definitions](#attribute-definition).  
 - The [name of the Service in the Model](#model-properties) must match the Name defined on the [Service](#services) instance.
 - Joined instances must be type [Model](#model) or [Entity](#entities).
-- If the attributes of an Entity have overlapping names with other attributes in that service, they must all have compatible or matching [attribute options](#attributes).   
-- All primary and global secondary indexes must have the same name field names and be written to assume SortKeys exist/don't exist in the same manor. See [Indexes](#indexes).
-- All models conform to the same model format. If you created your model prior to ElectroDB version 0.9.19 see section [Version 1 Migration](#version-1-migration). 
+- If the attributes of an Entity have overlapping names with other attributes in that service, they must all have compatible or matching [attribute definitions](#attributes).
+- All models conform to the same model format. If you created your model prior to ElectroDB version 0.9.19 see section [Version 1 Migration](#version-1-migration).
 
 ## Model 
 
@@ -586,7 +587,7 @@ attributes: {
 }
 ```
 
-#### Any Attributes 
+#### Attribute Definition 
 
 | Property | Type | Required | Description |
 | -------- | :--: | :--: | ----------- |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrodb",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "A library to more easily create and interact with multiple entities and heretical relationships in dynamodb",
   "main": "index.js",
   "scripts": {

--- a/src/entity.js
+++ b/src/entity.js
@@ -1600,7 +1600,7 @@ class Entity {
 			let indexName = index.index || "";
 			if (seenIndexes[indexName] !== undefined) {
 				if (indexName === "") {
-					throw new e.ElectroError(e.ErrorCodes.DuplicateIndexes, `Duplicate index defined in model found in Access Pattern '${accessPattern}': '${indexName || "(PRIMARY INDEX)"}'. This could be because you forgot to specify the index name of a secondary index defined in your model.`);
+					throw new e.ElectroError(e.ErrorCodes.DuplicateIndexes, `Duplicate index defined in model found in Access Pattern '${accessPattern}': '${indexName || "(Primary Index)"}'. This could be because you forgot to specify the index name of a secondary index defined in your model.`);
 				} else {
 					throw new e.ElectroError(e.ErrorCodes.DuplicateIndexes, `Duplicate index defined in model found in Access Pattern '${accessPattern}': '${indexName}'`);
 				}
@@ -1609,7 +1609,7 @@ class Entity {
 			let hasSk = !!index.sk;
 			let inCollection = !!index.collection;
 			if (!hasSk && inCollection) {
-				throw new e.ElectroError(e.ErrorCodes.CollectionNoSK, `Invalid Access pattern definition for '${accessPattern}': '${indexName || "(PRIMARY INDEX)"}', contains a collection definition without a defined SK. Collections can only be defined on indexes with a defined SK.`);
+				throw new e.ElectroError(e.ErrorCodes.CollectionNoSK, `Invalid Access pattern definition for '${accessPattern}': '${indexName || "(Primary Index)"}', contains a collection definition without a defined SK. Collections can only be defined on indexes with a defined SK.`);
 			}
 			let collection = index.collection || "";
 			let customFacets = {
@@ -1639,7 +1639,7 @@ class Entity {
 				parsedSKFacets = this._parseFacets(index.sk.facets);
 				let { facetArray, facetLabels } = parsedSKFacets;
 				customFacets.sk = parsedSKFacets.isCustom;
-        facets.labels[indexName] = Object.assign({}, facets.labels[indexName] || {}, facetLabels);
+				facets.labels[indexName] = Object.assign({}, facets.labels[indexName] || {}, facetLabels);
 				sk = {
 					facetLabels,
 					accessPattern,
@@ -1831,6 +1831,7 @@ class Entity {
 		let modelLabels = schema.getLabels();
 		for (let indexName of Object.keys(facets.labels)) {
 			facets.labels[indexName] = Object.assign({}, modelLabels, facets.labels[indexName]);
+			indexes[indexAccessPattern.fromIndexToAccessPattern[indexName]].labels = facets.labels[indexName];
 		}
 
 		return {

--- a/src/service.js
+++ b/src/service.js
@@ -264,28 +264,67 @@ class Service {
 		let indexMatch = definition.index === providedIndex.index;
 		let pkFieldMatch = definition.pk.field === providedIndex.pk.field;
 		let pkFacetLengthMatch = definition.pk.facets.length === providedIndex.pk.facets.length;
-		let pkFacetContentMatch;
+		let mismatchedFacetLabels = [];
 		let collectionDifferences = [];
+		let definitionIndexName = definition.index || "(Primary Index)";
+		let providedIndexName = providedIndex.index || "(Primary Index)";
 		for (let i = 0; i < definition.pk.facets.length; i++) {
-			pkFacetContentMatch = definition.pk.facets[i] === providedIndex.pk.facets[i];
-			if (!pkFacetContentMatch) {
-				break;
+			let definitionFacet = definition.pk.facets[i];
+			let definitionLabel = definition.labels[definitionFacet] !== undefined
+				? definition.labels[definitionFacet]
+				: definitionFacet;
+			let providedFacet = providedIndex.pk.facets[i];
+			let providedLabel = providedIndex.labels[providedFacet] !== undefined
+				? providedIndex.labels[providedFacet]
+				: providedFacet;
+			let noLabels = definition.labels[definitionFacet] === undefined && providedIndex.labels[providedFacet] === undefined;
+			if (definitionLabel !== providedLabel) {
+				mismatchedFacetLabels.push({
+					definitionFacet,
+					definitionLabel,
+					providedFacet,
+					providedLabel,
+					type: noLabels ? "facet" : "label"
+				});
+			} else if (definitionFacet !== providedFacet) {
+				mismatchedFacetLabels.push({
+					definitionFacet,
+					definitionLabel,
+					providedFacet,
+					providedLabel,
+					type: "facet"
+				});
 			}
 		}
 		if (!indexMatch) {
 			collectionDifferences.push(
-				`Index provided "${providedIndex.index}" does not match established index: ${definition.index || "[Main Table Index]"}`,
+				`Collection defined on provided index "${providedIndexName}" does not match collection established index "${definitionIndexName}". Collections must be defined on the same index across all entities within a service.`,
+			);
+		} else if (!pkFieldMatch) {
+			collectionDifferences.push(
+				`Partition Key facets provided "${providedIndex.pk.field}" for index "${providedIndexName}" do not match established field "${definition.pk.field}" on established index "${definitionIndexName}"`,
 			);
 		}
-		if (!pkFieldMatch) {
+		if (!pkFacetLengthMatch) {
 			collectionDifferences.push(
-				`Partition Key Field provided "${providedIndex.pk.field}" for index "${providedIndex.index}" does not match established field "${definition.pk.field}"`,
+				`Partition Key Facets provided [${providedIndex.pk.facets.map(val => `"${val}"`).join(", ")}] for index "${providedIndexName}" do not match established facets [${definition.pk.facets.map(val => `"${val}"`).join(", ")}] on established index "${definitionIndexName}"`,
 			);
-		}
-		if (!pkFacetLengthMatch || !pkFacetContentMatch) {
-			collectionDifferences.push(
-				`Partition Key Facets provided "${providedIndex.pk.facets.join(", ")}" do not match established facets "${definition.pk.facets.join(", ")}"`,
-			);
+		// Else if used here because if they don't even have the same facet length then the data collected for the mismatched facets would include undefined values
+		// which would make the error messages even more confusing.
+		} else if (mismatchedFacetLabels.length > 0) {
+
+			for (let mismatch of mismatchedFacetLabels) {
+				if (mismatch.type === "facet") {
+					collectionDifferences.push(
+						`Partition Key facets provided for index "${providedIndexName}" do not match established facet "${mismatch.definitionFacet}" on established index "${definitionIndexName}": "${mismatch.definitionLabel}" != "${mismatch.providedLabel}"; Facet definitions must match between all members of a collection to ensure key structures will resolve to identical Partition Keys. Please ensure these facet definitions are identical for all entities associated with this service.`
+					);
+				} else {
+					collectionDifferences.push(
+						`Partition Key facets provided for index "${providedIndexName}" contain conflicting facet labels for established facet "${mismatch.definitionFacet}" on established index "${definitionIndexName}". Established facet "${mismatch.definitionFacet}" on established index "${definitionIndexName}" was defined with label "${mismatch.definitionLabel}" while provided facet "${mismatch.providedFacet}" on provided index "${providedIndexName}" is defined with label "${mismatch.providedLabel}". Facet labels definitions must match between all members of a collection to ensure key structures will resolve to identical Partition Keys. Please ensure these labels definitions are identical for all entities associated with this service.`
+					);
+				}
+
+			}
 		}
 		return [!!collectionDifferences.length, collectionDifferences];
 	}
@@ -324,6 +363,7 @@ class Service {
 		if (!Object.keys(definition).length) {
 			definition = {
 				index: providedIndex.index || "",
+				labels: providedIndex.labels || {},
 				pk: {
 					field: providedIndex.pk.field,
 					facets: providedIndex.pk.facets,
@@ -334,10 +374,10 @@ class Service {
 				},
 			};
 		}
-			let [invalidDefinition, invalidIndexMessages] = this._validateCollectionDefinition(definition, providedIndex);
-			if (invalidDefinition) {
-				throw new e.ElectroError(e.ErrorCodes.InvalidJoin, `Invalid entity index definitions. The following index definitions have already been defined on this model but with incompatible or conflicting properties: ${invalidIndexMessages.join(", ")}`);
-			}
+		let [invalidDefinition, invalidIndexMessages] = this._validateCollectionDefinition(definition, providedIndex);
+		if (invalidDefinition) {
+			throw new e.ElectroError(e.ErrorCodes.InvalidJoin, invalidIndexMessages.join(", "));
+		}
 		return definition;
 	}
 

--- a/test/offline.entity.spec.js
+++ b/test/offline.entity.spec.js
@@ -560,7 +560,7 @@ describe("Entity", () => {
 				}
 			};
 
-			let error = "Invalid Access pattern definition for 'store': '(PRIMARY INDEX)', contains a collection definition without a defined SK. Collections can only be defined on indexes with a defined SK.";
+			let error = "Invalid Access pattern definition for 'store': '(Primary Index)', contains a collection definition without a defined SK. Collections can only be defined on indexes with a defined SK.";
 			expect(() => new Entity(schema)).to.throw(error);
 		});
 		it("Should identify impacted indexes from attributes", () => {
@@ -3030,7 +3030,7 @@ describe("Entity", () => {
 				it("throw when a collection is added to an index without an SK", () => {
 					let model = JSON.parse(base);
 					delete model.indexes.thing.sk;
-					expect(() => new Entity(model)).to.throw("Invalid Access pattern definition for 'thing': '(PRIMARY INDEX)', contains a collection definition without a defined SK. Collections can only be defined on indexes with a defined SK. - For more detail on this error reference: https://github.com/tywalch/electrodb#collection-without-an-sk");
+					expect(() => new Entity(model)).to.throw("Invalid Access pattern definition for 'thing': '(Primary Index)', contains a collection definition without a defined SK. Collections can only be defined on indexes with a defined SK. - For more detail on this error reference: https://github.com/tywalch/electrodb#collection-without-an-sk");
 				});
 				it("should ignore collection when sk is custom", () => {
 					let model = JSON.parse(base);
@@ -3098,7 +3098,7 @@ describe("Entity", () => {
 				it("throw when a collection is added to an index without an SK", () => {
 					let model = JSON.parse(base);
 					delete model.indexes.thing.sk;
-					expect(() => new Entity(model)).to.throw("Invalid Access pattern definition for 'thing': '(PRIMARY INDEX)', contains a collection definition without a defined SK. Collections can only be defined on indexes with a defined SK. - For more detail on this error reference: https://github.com/tywalch/electrodb#collection-without-an-sk");
+					expect(() => new Entity(model)).to.throw("Invalid Access pattern definition for 'thing': '(Primary Index)', contains a collection definition without a defined SK. Collections can only be defined on indexes with a defined SK. - For more detail on this error reference: https://github.com/tywalch/electrodb#collection-without-an-sk");
 				});
 				it("should ignore collection when sk is custom", () => {
 					let model = JSON.parse(base);
@@ -3338,7 +3338,7 @@ describe("Entity", () => {
 					}
 				}
 			};
-			expect(() => new Entity(schema)).to.throw("Duplicate index defined in model found in Access Pattern 'index2': '(PRIMARY INDEX)'. This could be because you forgot to specify the index name of a secondary index defined in your model. - For more detail on this error reference: https://github.com/tywalch/electrodb#duplicate-indexes")
+			expect(() => new Entity(schema)).to.throw("Duplicate index defined in model found in Access Pattern 'index2': '(Primary Index)'. This could be because you forgot to specify the index name of a secondary index defined in your model. - For more detail on this error reference: https://github.com/tywalch/electrodb#duplicate-indexes")
 		});
 		it("Should check for duplicate indexes on secondary index", () => {
 			let schema = {


### PR DESCRIPTION
…matching facet names, but did not validate that the facets also had matching labels. This PR still requires matching facet names (or else there would be ambiguity in collection queries) but now also checks to see that the labels are equal.