### PR TITLE
ElectroDB would throw when an `undefined` property was passed to quer…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,29 +60,32 @@ All notable changes to this project will be documented in this file. Breaking ch
 - TypeScript type definitions for `get()` method now incorporate potential for `null` response.
 - Type definitions for `value()` and `name()` where clause operations.  
 
-### [1.3.1] - 2021-08-09
+## [1.3.1] - 2021-08-09
 ### Added
 - New entity method `parse()` to expose ElectroDB formatting for values retrieved outside of ElectroDB. [[read more]](./README.md#parse)
 
-### [1.3.2] - 2021-08-11
+## [1.3.2] - 2021-08-11
 ### Fixed
 - Newly added method `parse()` had critical typo. Method now has an improved api, and appropriate tests [[read more]](./README.md#parse)
 
-### [1.4.0] - 2021-08-22
+## [1.4.0] - 2021-08-22
 ### Added 
 - Added support for choosing the case ElectroDB will use when modeling a Partition or Sort Key. [[read more]](./README.md#using-electrodb-with-existing-data)
 - Added support for indexes to use fields that are shared with attribute fields. This should help users leverage ElectroDB with existing tables. [[read more]](./README.md#using-electrodb-with-existing-data)
 - Added Query Option `ignoreOwnership` to bypass ElectroDB checks/interrogations for ownership of an item before returning it. [[read more]](./README.md#query-options)
 
-### [1.4.1] - 2021-08-25
+## [1.4.1] - 2021-08-25
 ### Added
 - Typedef support for RegExp validation on string attributes
 
 ### Fixed
 - RegExp validation issue resulting in undefined (but not required) values being tested.
 
-### [1.4.2] - 2021-09-09
-
+## [1.4.2] - 2021-09-09
 ### Fixed
 - Typing for `.page()` method pager. Now includes the destructured keys associated with the index being queried. [[read more]](./README.md#page)
 - Adding documentation, and expanding typing for the query option `limit`, for use in `.params()` calls. [[read more]](./README.md#query-options)
+
+## [1.4.3] - 2021-10-03
+### Fixed
+- ElectroDB would throw when an `undefined` property was passed to query. This has been changed to not throw if a partial query on that index can be accomplished with the data provided.

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@
 
 ------------
 
-<h1 align="center">Introducing: ElectroDB Playground @ electrodb.fun</h1>
+<a href="https://electrodb.fun"><h1 align="center">Introducing: The NEW ElectroDB Playground</h1></a>
 
 <p align="center">
-  <a href="https://electrodb.fun"><img width="500" src="https://github.com/tywalch/electrodb/blob/master/assets/playground.jpg?raw=true"></a>
+  <a href="https://electrodb.fun"><img width="400" src="https://github.com/tywalch/electrodb/blob/master/assets/playground.jpg?raw=true"></a>
 </p>
 
-<p align="center">Try out and share ElectroDB Models, Services, and Single Table Design at <a href="https://electrodb.fun">https://electrodb.fun</a></p>
+<p align="center">Try out and share ElectroDB Models, Services, and Single Table Design at <a href="https://electrodb.fun">electrodb.fun</a></p>
 
 ------------
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrodb",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "A library to more easily create and interact with multiple entities and heretical relationships in dynamodb",
   "main": "index.js",
   "scripts": {

--- a/src/clauses.js
+++ b/src/clauses.js
@@ -38,7 +38,6 @@ let clauses = {
 				return state;
 			}
 			try {
-				entity._expectFacets(facets, Object.keys(facets), `"query collection" composite attributes`);
 				const {pk} = state.getCompositeAttributes();
 				return state
 					.setType(QueryTypes.collection)
@@ -381,7 +380,6 @@ let clauses = {
 			}
 			try {
 				const attributes = state.getCompositeAttributes();
-				entity._expectFacets(facets, Object.keys(facets), `"query" composite attributes`);
 				return state
 					.setMethod(MethodTypes.query)
 					.setType(QueryTypes.is)
@@ -404,16 +402,6 @@ let clauses = {
 			}
 			try {
 				const attributes = state.getCompositeAttributes();
-				entity._expectFacets(
-					startingFacets,
-					Object.keys(startingFacets),
-					`"between" composite attributes`,
-				);
-				entity._expectFacets(
-					endingFacets,
-					Object.keys(endingFacets),
-					`"and" composite attributes`,
-				);
 				return state
 					.setType(QueryTypes.and)
 					.setSK(entity._buildQueryFacets(endingFacets, attributes.sk))
@@ -433,8 +421,6 @@ let clauses = {
 				return state;
 			}
 			try {
-				entity._expectFacets(facets, Object.keys(facets), `"begins" composite attributes`);
-
 				return state
 					.setType(QueryTypes.begins)
 					.ifSK(state => {
@@ -455,7 +441,6 @@ let clauses = {
 				return state;
 			}
 			try {
-				entity._expectFacets(facets, Object.keys(facets), `"gt" composite attributes`);
 				return state
 					.setType(QueryTypes.gt)
 					.ifSK(state => {
@@ -476,7 +461,6 @@ let clauses = {
 				return state;
 			}
 			try {
-				entity._expectFacets(facets, Object.keys(facets), `"gte" composite attributes`);
 				return state
 					.setType(QueryTypes.gte)
 					.ifSK(state => {
@@ -497,7 +481,6 @@ let clauses = {
 				return state;
 			}
 			try {
-				entity._expectFacets(facets, Object.keys(facets), `"lt" composite attributes`);
 				return state.setType(QueryTypes.lt)
 					.ifSK(state => {
 						const attributes = state.getCompositeAttributes();
@@ -517,7 +500,6 @@ let clauses = {
 				return state;
 			}
 			try {
-				entity._expectFacets(facets, Object.keys(facets), `"lte" composite attributes`);
 				return state.setType(QueryTypes.lte)
 					.ifSK(state => {
 						const attributes = state.getCompositeAttributes();

--- a/src/entity.js
+++ b/src/entity.js
@@ -1095,12 +1095,14 @@ class Entity {
 		let restrict = ["pk"];
 		let keys = { pk };
 		sks = sks.filter(sk => sk !== undefined);
+
 		for (let i = 0; i < sks.length; i++) {
 			let id = `sk${i + 1}`;
 			keys[id] = sks[i];
 			restrict.push(id);
 			translate[id] = translate["sk"];
 		}
+
 		let keyExpressions = this._expressionAttributeBuilder(keys, ItemOperations.set, {
 			translate,
 			restrict,


### PR DESCRIPTION
ElectroDB would throw when an `undefined` property was passed to query. This has been changed to not throw if a partial query on that index can be accomplished with the data provided.