### PR TITLE
fix: use update method in update.mdx example

### DIFF
--- a/www/src/pages/en/mutations/update.mdx
+++ b/www/src/pages/en/mutations/update.mdx
@@ -24,7 +24,7 @@ The `update()` method in ElectroDB allows you to update individual properties of
 
 ```typescript
 tasks
-  .patch({
+  .update({
     team: "core",
     task: "45-662",
     project: "backend"


### PR DESCRIPTION
As per title, the basic example for `update` uses `patch` instead.