### PR TITLE
Upsert Can't handle required 'false' boolean values

### DIFF
--- a/src/entity.js
+++ b/src/entity.js
@@ -1494,7 +1494,12 @@ class Entity {
 		update.set(this.identifiers.entity, this.getName());
 		update.set(this.identifiers.version, this.getVersion());
 		for (const field of [...Object.keys(upsertAttributes), ...Object.keys(updatedKeys)]) {
-			const value = upsertAttributes[field] || updatedKeys[field];
+			// Need to check for undefined/null since short circuiting would get rid of valid 'falsey' values i.e. a false boolean
+			const isNullOrUndefined = (val) => val === undefined || val === null
+			const valueFromUpsertAttributes = upsertAttributes[field]
+			const valueFromKeyAttribues = updatedKeys[field]
+			
+			const value = !isNullOrUndefined(valueFromUpsertAttributes) ? valueFromUpsertAttributes : valueFromKeyAttribues;
 			if (!keyNames.includes(field)) {
 				update.set(field, value);
 			}

--- a/src/entity.js
+++ b/src/entity.js
@@ -1494,12 +1494,7 @@ class Entity {
 		update.set(this.identifiers.entity, this.getName());
 		update.set(this.identifiers.version, this.getVersion());
 		for (const field of [...Object.keys(upsertAttributes), ...Object.keys(updatedKeys)]) {
-			// Need to check for undefined/null since short circuiting would get rid of valid 'falsey' values i.e. a false boolean
-			const isNullOrUndefined = (val) => val === undefined || val === null
-			const valueFromUpsertAttributes = upsertAttributes[field]
-			const valueFromKeyAttribues = updatedKeys[field]
-			
-			const value = !isNullOrUndefined(valueFromUpsertAttributes) ? valueFromUpsertAttributes : valueFromKeyAttribues;
+			const value = u.getFirstDefined(upsertAttributes[field], updatedKeys[field]);
 			if (!keyNames.includes(field)) {
 				update.set(field, value);
 			}
@@ -3028,7 +3023,7 @@ class Entity {
 				if (sk.isCustom) {
 					definitions[indexName].sk.push({name, label});
 				} else {
-					definitions[indexName].sk.push({name, label: fromModel[name] || name});
+					definitions[indexName].sk.push({name, label: u.getFirstDefined(fromModel[name], name) });
 				}
 			}
 		}

--- a/src/util.js
+++ b/src/util.js
@@ -233,6 +233,10 @@ function shiftSortOrder(str = '', codePoint) {
   return newString;
 }
 
+function getFirstDefined(...params) {
+  return params.find(val => val !== undefined);
+}
+
 module.exports = {
   getUnique,
   batchItems,
@@ -241,6 +245,7 @@ module.exports = {
   removeFixings,
   parseJSONPath,
   shiftSortOrder,
+  getFirstDefined,
   getInstanceType,
   getModelVersion,
   formatKeyCasing,

--- a/test/ts_connected.crud.spec.ts
+++ b/test/ts_connected.crud.spec.ts
@@ -4160,6 +4160,7 @@ describe('upsert', () => {
         }).go({response: 'all_new'});
 
         expect(initialUpsert.data).to.deep.equal({
+            complete,
             project,
             task,
             team,
@@ -4171,6 +4172,7 @@ describe('upsert', () => {
         const record = await tasks.get({task, project}).go();
 
         expect(record.data).to.deep.equal({
+            complete,
             project,
             task,
             team,
@@ -4256,6 +4258,9 @@ describe('upsert', () => {
                                 type: 'string'
                             }
                         }
+                    },
+                    complete: {
+                        type: 'boolean'
                     }
                 },
                 indexes: {

--- a/test/ts_connected.crud.spec.ts
+++ b/test/ts_connected.crud.spec.ts
@@ -4061,6 +4061,10 @@ describe('upsert', () => {
                     type: "string",
                     required: true
                 },
+                complete: {
+                    type: 'boolean',
+                    required: true
+                },
                 title: {
                     type: 'string',
                 },
@@ -4109,8 +4113,10 @@ describe('upsert', () => {
             twitter: '@tywalch',
         }
         const title = 'Bugfix #921';
+        const complete = false;
         const initialUpsert = await tasks.upsert({
             project,
+            complete,
             task,
             team,
             flags,
@@ -4119,6 +4125,7 @@ describe('upsert', () => {
         }).go({response: 'all_new'});
         const expected = {
             project,
+            complete,
             task,
             team,
             flags,
@@ -4140,9 +4147,11 @@ describe('upsert', () => {
         }
         const title = 'Bugfix #921';
         const description = 'Users experience degraded performance';
+        const complete = true;
 
         const initialUpsert = await tasks.upsert({
             project,
+            complete,
             task,
             team,
             flags,
@@ -4176,6 +4185,7 @@ describe('upsert', () => {
             team,
             description,
             flags: ['groomed', 'tech_debt'],
+            complete: false,
         }).go({response: 'all_new'});
 
         expect(upsertedOverExisting.data).to.deep.equal({
@@ -4183,6 +4193,7 @@ describe('upsert', () => {
             task,
             team,
             flags: ['groomed', 'tech_debt'],
+            complete: false,
             integrations,
             title,
             description,
@@ -4194,6 +4205,7 @@ describe('upsert', () => {
             task,
             team,
             flags: ['groomed', 'tech_debt'],
+            complete: false,
             integrations,
             title,
             description,
@@ -4283,9 +4295,11 @@ describe('upsert', () => {
         }
         const title = 'Bugfix #921';
         const description = 'Users experience degraded performance';
+        const complete = true;
         expect(() => {
             const upsert = tasks.upsert({
                 project,
+                complete,
                 task,
                 team,
                 flags,


### PR DESCRIPTION
When trying to run `upsert` command, it errors if passing in a boolean attribute that is 'required' and is set to `false`. It seemed that the dynamo command created includes the attribute in `ExpressionAttributeNames` but did not pass through the value correctly into the `ExpressionAttributeValues` object, it instead sets it to `undefined`. This causes the following error to be thrown by the document client

```
ElectroError: Pass options.removeUndefinedValues=true to remove undefined values from map/array/set. - For more detail on this error reference: https://github.com/tywalch/electrodb#aws-error
```


I think I hunted down where the bug came from, it seems it was due to the following line short circuiting on the value of `upsertAttributes[field]` which was fine in most cases, except for when that value equals `false` in which case it looks for `updatedKeys[field]` and then value gets assigned `undefined`
```typescript
const value = upsertAttributes[field] || updatedKeys[field];
```

Im not super familiar with the Electro codebase and just hunted this down with some logs etc, but please feel free to redo if what i have done would break anything. I just figured i could hopefully make a good start :) 