### PR TITLE
Fix broken documentation links

### DIFF
--- a/www/src/config.ts
+++ b/www/src/config.ts
@@ -31,7 +31,7 @@ export const KNOWN_LANGUAGES = {
 } as const;
 export const KNOWN_LANGUAGE_CODES = Object.values(KNOWN_LANGUAGES);
 
-export const GITHUB_EDIT_URL = `https://github.com/tywalch/electrodb/www`;
+export const GITHUB_EDIT_URL = `https://github.com/tywalch/electrodb/tree/master/www`;
 
 export const COMMUNITY_INVITE_URL = `https://github.com/tywalch/electrodb/discussions`;
 


### PR DESCRIPTION
### Changes

- Fixes to documentation links that currently give 404s.

### Before merging

- Please check verify that links work (could not check this myself, since e.g., the "Edit this page" button link seems to generated).