### PR TITLE
Update query.mdx

### DIFF
--- a/www/src/pages/en/queries/query.mdx
+++ b/www/src/pages/en/queries/query.mdx
@@ -45,7 +45,7 @@ await StoreLocations.query.stores({
 await StoreLocations.query.stores({
     cityId: 'Atlanta1',
     mallId: 'EastPointe',
-    storeId: 'LatteLarrys',
+    buildingId: 'f34',
 }).go();
 ```
 
@@ -56,7 +56,7 @@ await StoreLocations.query.stores({
     cityId: 'Atlanta1',
     mallId: 'EastPointe',
     storeId: 'LatteLarrys',
-    unitId: 'B24',
+    buildingId: 'f34',
 }).go();
 ```
 


### PR DESCRIPTION
The entity definition states that the SK for the stores index contains buildingId and storeId, in that order, but the docs seemed incorrect:

first issue: `Good: Includes at least the PK, and the first SK attribute`

the example used storeId, but the entity definition listed buildingId as the first sk attribute

second issue: `Good: Includes at least the PK, and the all SK attributes

the example was using unitId, but unitId isn't part of the stores index.

<img width="525" alt="Screenshot 2023-05-10 at 11 23 51 AM" src="https://github.com/tywalch/electrodb/assets/1868782/b99ba5b3-1ef5-4e80-b5f4-241678dc5f7b">

close if this seems wrong, thank you
