### PR TITLE
Fix Example: Errors on shopping mall example

### DIFF
--- a/www/src/pages/en/examples/shopping-mall-directory.mdx
+++ b/www/src/pages/en/examples/shopping-mall-directory.mdx
@@ -151,7 +151,7 @@ Fulfilling [Requirement #1](#shopping-mall-requirements).
 let mallId = "EastPointe";
 
 let stores = await StoreLocations.query
-    .malls({ mallId })
+    .units({ mallId })
     .go();
 ```
 
@@ -164,7 +164,7 @@ let mallId = "EastPointe";
 let buildingId = "BuildingA1";
 
 let stores = await StoreLocations.query
-    .malls({ mallId, buildingId })
+    .units({ mallId, buildingId })
     .go();
 ```
 
@@ -178,7 +178,7 @@ let buildingId = "BuildingA1";
 let unitId = "B47";
 
 let stores = await StoreLocations.query
-    .malls({ mallId, buildingId, unitId })
+    .units({ mallId, buildingId, unitId })
     .go();
 ```
 
@@ -191,7 +191,7 @@ let mallId = "EastPointe";
 let category = "food/coffee";
 
 let stores = await StoreLocations.query
-    .malls({mallId})
+    .units({ mallId })
     .where((attr, op) => op.eq(attr.category, category))
     .go();
 ```
@@ -200,12 +200,12 @@ let stores = await StoreLocations.query
 Fulfilling [Requirement #3](#shopping-mall-requirements).
 
 ```typescript
-let mallId = "EastPointe";
+let storeId = "LatteLarrys";
 let q2StartDate = "2020-04-01";
 
 let stores = await StoreLocations.query
-    .leases({mallId})
-    .lt({leaseEndDate: q2StateDate})
+    .leases({ storeId })
+    .lt({leaseEndDate: q2StartDate})
     .go();
 ```
 
@@ -214,11 +214,12 @@ let stores = await StoreLocations.query
 Fulfilling [Requirement #3](#shopping-mall-requirements).
 
 ```typescript
-let mallId = "EastPointe";
+let storeId = "LatteLarrys";
 let q4StartDate = "2020-10-01";
 let q4EndDate = "2020-12-31";
 
-let stores = await StoreLocations.leases(mallId)
+let stores = await StoreLocations.query
+    .leases({ storeId })
     .between(
         { leaseEndDate: q4StartDate },
         { leaseEndDate: q4EndDate })
@@ -230,13 +231,13 @@ let stores = await StoreLocations.leases(mallId)
 Fulfilling [Requirement #3](#shopping-mall-requirements).
 
 ```typescript
-let mallId = "EastPointe";
+let storeId = "LatteLarrys";
 let yearStarDate = "2020-01-01";
 let yearEndDate = "2020-12-31";
 let storeId = "LatteLarrys";
 
-let stores = await StoreLocations.leases(mallId)
-    .between (
+let stores = await StoreLocations.query
+    .leases({ storeId })    .between (
       { leaseEndDate: yearStarDate },
       { leaseEndDate: yearEndDate })
     .where((attr, op) => op.eq(attr.category, "Spite Store"))
@@ -252,6 +253,6 @@ let unitId = "B47";
 let storeId = "LatteLarrys";
 
 let stores = await StoreLocations.query
-    .malls({ mallId, buildingId, storeId })
+    .units({ mallId, buildingId, storeId })
     .go();
 ```

--- a/www/src/partials/entity-query-example-setup.mdx
+++ b/www/src/partials/entity-query-example-setup.mdx
@@ -50,6 +50,22 @@
           "Projection":{
               "ProjectionType":"ALL"
           }
+      },
+      {
+          "IndexName":"gsi2pk-gsi2sk-index",
+          "KeySchema":[
+              {
+                  "AttributeName":"gsi2pk",
+                  "KeyType":"HASH"
+              },
+              {
+                  "AttributeName":"gsi2sk",
+                  "KeyType":"RANGE"
+              }
+          ],
+          "Projection":{
+              "ProjectionType":"ALL"
+          }
       }
   ],
   "BillingMode":"PAY_PER_REQUEST"


### PR DESCRIPTION
A few errors exist if you put the shopping mall example into the playground. I **only** fixed the `typos` so that playground wouldn't throw errors. I updated the access pattern keywords based on indexes of the example setup.

However, semantically queries don't make sense. I believe you wanted to use `mallId` in [example setup index](https://github.com/tywalch/electrodb/blob/44853b3ba453715b6eaddd7e6378d0eae40499f9/www/src/partials/entity-query-example-setup.mdx#L152C39-L152C39) and then queries make sense but since it is used in many places I didn't want to touch it. 

I think this is the **most well-thought** library for dynamodb I have seen in years. Good work!