### PR TITLE
Update schema.mdx

### DIFF
--- a/www/src/pages/en/modeling/schema.mdx
+++ b/www/src/pages/en/modeling/schema.mdx
@@ -117,9 +117,8 @@ In the below `model` example, ElectroDB will define isolation with the following
 
 The [Attributes page](/en/modeling/attributes) contains everything you need to know about attributes in ElectroDB. In the context of an overall schema, the `attributes` object defines all attributes that can be defined on an entity item. Additionally, the [indexes object](#indexes) will reference attributes defined here.
 
-:::caution
-The `attributes` object should not contain fields that represent your partition or sort keys. ElectroDB creates mappings to your partition and sort keys in the [indexes object](#indexes).
-:::
+> The `attributes` object should not contain fields that represent your partition or sort keys. ElectroDB creates mappings to your partition and sort keys in the [indexes object](#indexes).
+
 
 ```typescript
 {


### PR DESCRIPTION
The admonition `:::caution` was rendered properly. I couldn't find any info in the [Astro docs](https://docs.astro.build/en/guides/markdown-content/) or [MDX docs](https://mdxjs.com/). To render these admonition, a plugin like [remark-admonitions](https://github.com/elviswolcott/remark-admonitions) seems to be needed. 

However, I assume it's a leftover from previous versions of the docs, as there are only two instances of `:::caution` in the docs.

![image](https://github.com/tywalch/electrodb/assets/950244/5b758209-f018-459a-ae82-ce1de527af14)
![image](https://github.com/tywalch/electrodb/assets/950244/7a1f701e-6cc3-475e-acd8-7cbb52034ed1)
