### PR TITLE
Fixes issue 319

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -470,6 +470,10 @@ All notable changes to this project will be documented in this file. Breaking ch
 ### Fixed
 - Addresses edge case that filtered valid items when item lacked entity identifiers (created outside ElectroDB) when keys (pk or sk) were numeric.
 
-## [2.10.3] - 2023-10-26
+## [2.10.4] - 2023-10-26
 ### Added
 - Adds `cause` property to `ElectroError`, currently populated when error originates from the AWS Client, to help with error triage. This also adds the ability to provide an error type to ElectroError<Error> to type the error located on `cause`.
+
+## [2.10.5] - 2023-11-03
+### Fixed
+- Addresses bug in `patch` and `update` methods that caused key composite attributes to be set with their attribute name not their "field" name. This would impact users who both use the `update` method to create new items and use alternative field name definitions for their composite keys. All other users would likely be silently impacted by this issue. 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrodb",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "description": "A library to more easily create and interact with multiple entities and heretical relationships in dynamodb",
   "main": "index.js",
   "scripts": {

--- a/src/entity.js
+++ b/src/entity.js
@@ -2317,7 +2317,7 @@ class Entity {
           // TODO: This will only work with root attributes and should be refactored for nested attributes.
           update.set(attr.field, preparedUpdateValues[path]);
         } else {
-          // this could be fields added by electro that don't apeear in the schema
+          // this could be fields added by electro that don't appear in the schema
           update.set(path, preparedUpdateValues[path]);
         }
       }
@@ -2369,7 +2369,7 @@ class Entity {
         modifiedAttributeNames[primaryIndexAttribute] === undefined;
       if (isNotTablePK && isNotTableSK && wasNotAlreadyModified) {
         update.set(
-          primaryIndexAttribute,
+          attribute.field,
           primaryIndexAttributes[primaryIndexAttribute],
         );
       }

--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,13 @@ function finish {
   docker compose down
 }
 
-trap finish EXIT
-
 docker compose up -d
-docker compose exec electro npm run test:run; finish;
+docker compose exec electro npm run test:run;
+if [ $? -eq 0 ]; then
+  finish
+else
+  finish
+  exit 1
+fi
+
+

--- a/test/offline.entity.spec.js
+++ b/test/offline.entity.spec.js
@@ -1955,9 +1955,9 @@ describe("Entity", () => {
         .params();
       expect(update).to.deep.equal({
         UpdateExpression:
-          "SET #mall = :mall_u0, #store = :store_u0, #building = :building_u0, #category = :category_u0, #unit = :unit_u0, #rent = :rent_u0, #leaseEnd = :leaseEnd_u0, #gsi1pk = :gsi1pk_u0, #gsi1sk = :gsi1sk_u0, #gsi2pk = :gsi2pk_u0, #gsi2sk = :gsi2sk_u0, #gsi3pk = :gsi3pk_u0, #gsi3sk = :gsi3sk_u0, #gsi4pk = :gsi4pk_u0, #gsi4sk = :gsi4sk_u0, #id = :id_u0, #__edb_e__ = :__edb_e___u0, #__edb_v__ = :__edb_v___u0",
+          "SET #mall = :mall_u0, #store = :store_u0, #building = :building_u0, #category = :category_u0, #unit = :unit_u0, #rent = :rent_u0, #leaseEnd = :leaseEnd_u0, #gsi1pk = :gsi1pk_u0, #gsi1sk = :gsi1sk_u0, #gsi2pk = :gsi2pk_u0, #gsi2sk = :gsi2sk_u0, #gsi3pk = :gsi3pk_u0, #gsi3sk = :gsi3sk_u0, #gsi4pk = :gsi4pk_u0, #gsi4sk = :gsi4sk_u0, #storeLocationId = :storeLocationId_u0, #__edb_e__ = :__edb_e___u0, #__edb_v__ = :__edb_v___u0",
         ExpressionAttributeNames: {
-          "#id": "id",
+          "#storeLocationId": "storeLocationId",
           "#mall": "mall",
           "#store": "storeId",
           "#building": "buildingId",
@@ -1977,7 +1977,7 @@ describe("Entity", () => {
           "#__edb_v__": "__edb_v__",
         },
         ExpressionAttributeValues: {
-          ":id_u0": id,
+          ":storeLocationId_u0": id,
           ":mall_u0": mall,
           ":store_u0": store,
           ":building_u0": building,

--- a/test/offline.where.spec.js
+++ b/test/offline.where.spec.js
@@ -208,20 +208,20 @@ describe("Offline Where", () => {
 
     expect(updateParams).to.deep.equal({
       UpdateExpression:
-        "SET #dangerous = :dangerous_u0, #pen = :pen_u0, #row = :row_u0, #__edb_e__ = :__edb_e___u0, #__edb_v__ = :__edb_v___u0",
+        "SET #dangerous = :dangerous_u0, #p = :p_u0, #r = :r_u0, #__edb_e__ = :__edb_e___u0, #__edb_v__ = :__edb_v___u0",
       ExpressionAttributeNames: {
         "#animal": "a",
         "#dangerous": "d",
-        "#pen": "pen",
-        "#row": "row",
+        "#p": "p",
+        "#r": "r",
         "#__edb_e__": "__edb_e__",
         "#__edb_v__": "__edb_v__",
       },
       ExpressionAttributeValues: {
         ":animal0": "cow",
         ":dangerous_u0": false,
-        ":pen_u0": "abc",
-        ":row_u0": "def",
+        ":p_u0": "abc",
+        ":r_u0": "def",
         ":__edb_e___u0": "filters",
         ":__edb_v___u0": "1",
       },
@@ -232,12 +232,12 @@ describe("Offline Where", () => {
 
     expect(patchParams).to.deep.equal({
       UpdateExpression:
-        "SET #dangerous = :dangerous_u0, #pen = :pen_u0, #row = :row_u0, #__edb_e__ = :__edb_e___u0, #__edb_v__ = :__edb_v___u0",
+        "SET #dangerous = :dangerous_u0, #p = :p_u0, #r = :r_u0, #__edb_e__ = :__edb_e___u0, #__edb_v__ = :__edb_v___u0",
       ExpressionAttributeNames: {
         "#animal": "a",
         "#dangerous": "d",
-        "#pen": "pen",
-        "#row": "row",
+        "#p": "p",
+        "#r": "r",
         "#__edb_e__": "__edb_e__",
         "#__edb_v__": "__edb_v__",
         "#pk": "pk",
@@ -246,8 +246,8 @@ describe("Offline Where", () => {
       ExpressionAttributeValues: {
         ":animal0": "cow",
         ":dangerous_u0": false,
-        ":pen_u0": "abc",
-        ":row_u0": "def",
+        ":p_u0": "abc",
+        ":r_u0": "def",
         ":__edb_e___u0": "filters",
         ":__edb_v___u0": "1",
       },


### PR DESCRIPTION
Addresses bug in "patch" and "update" methods that caused key composite attributes to be set with their attribute name not their "field" name. This would impact users who both use the `update` method to create new items and use alternative field name definitions for their composite keys. All other users would likely be silently impacted by this issue.