### PR TITLE
Adds new property `namespace` to index definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -486,3 +486,7 @@ All notable changes to this project will be documented in this file. Breaking ch
 ## [2.10.7] - 2023-11-09
 ### Fixed
 - Fixes latency issue introduced in `2.10.4` affecting all queries discovered and brought forward by Ross Gerbasi. Thank you, Ross Gerbasi!
+
+## [2.11.0] - 2023-11-12
+### Added
+- Adds new property `scope` to index definitions, allowing users to further isolate partition keys beyond just `service` participation. This implements an RFC that was thoughtfully put forward by [@Sam3d](https://github.com/sam3d) in [Issue #290](https://github.com/tywalch/electrodb/issues/290).  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -489,4 +489,4 @@ All notable changes to this project will be documented in this file. Breaking ch
 
 ## [2.11.0] - 2023-11-12
 ### Added
-- Adds new property `namespace` to index definitions, allowing users to further isolate partition keys beyond just `service` participation. This implements an RFC that was thoughtfully put forward by [@Sam3d](https://github.com/sam3d) in [Issue #290](https://github.com/tywalch/electrodb/issues/290).  
+- Adds new property `namespace` to index definitions, allowing users to further isolate partition keys beyond just `service` participation. This implements an RFC that was thoughtfully put forward by [@Sam3d](https://github.com/sam3d) in [Issue #290](https://github.com/tywalch/electrodb/issues/290). Thank you, Brooke for your contribution!  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -489,4 +489,4 @@ All notable changes to this project will be documented in this file. Breaking ch
 
 ## [2.11.0] - 2023-11-12
 ### Added
-- Adds new property `scope` to index definitions, allowing users to further isolate partition keys beyond just `service` participation. This implements an RFC that was thoughtfully put forward by [@Sam3d](https://github.com/sam3d) in [Issue #290](https://github.com/tywalch/electrodb/issues/290).  
+- Adds new property `namespace` to index definitions, allowing users to further isolate partition keys beyond just `service` participation. This implements an RFC that was thoughtfully put forward by [@Sam3d](https://github.com/sam3d) in [Issue #290](https://github.com/tywalch/electrodb/issues/290).  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -489,4 +489,4 @@ All notable changes to this project will be documented in this file. Breaking ch
 
 ## [2.11.0] - 2023-11-12
 ### Added
-- Adds new property `namespace` to index definitions, allowing users to further isolate partition keys beyond just `service` participation. This implements an RFC that was thoughtfully put forward by [@Sam3d](https://github.com/sam3d) in [Issue #290](https://github.com/tywalch/electrodb/issues/290). Thank you, Brooke for your contribution!  
+- Adds new property `scope` to index definitions, allowing users to further isolate partition keys beyond just `service` participation. This implements an RFC that was thoughtfully put forward by [@Sam3d](https://github.com/sam3d) in [Issue #290](https://github.com/tywalch/electrodb/issues/290). Thank you, Brooke for your contribution!  

--- a/index.d.ts
+++ b/index.d.ts
@@ -3655,7 +3655,7 @@ export interface Schema<A extends string, F extends string, C extends string> {
     [accessPattern: string]: {
       readonly project?: "keys_only";
       readonly index?: string;
-      readonly scope?: string;
+      readonly namespace?: string;
       readonly type?: "clustered" | "isolated";
       readonly collection?: AccessPatternCollection<C>;
       readonly pk: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -3655,7 +3655,7 @@ export interface Schema<A extends string, F extends string, C extends string> {
     [accessPattern: string]: {
       readonly project?: "keys_only";
       readonly index?: string;
-      readonly namespace?: string;
+      readonly scope?: string;
       readonly type?: "clustered" | "isolated";
       readonly collection?: AccessPatternCollection<C>;
       readonly pk: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -3655,6 +3655,7 @@ export interface Schema<A extends string, F extends string, C extends string> {
     [accessPattern: string]: {
       readonly project?: "keys_only";
       readonly index?: string;
+      readonly scope?: string;
       readonly type?: "clustered" | "isolated";
       readonly collection?: AccessPatternCollection<C>;
       readonly pk: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrodb",
-  "version": "2.10.7",
+  "version": "2.11.0",
   "description": "A library to more easily create and interact with multiple entities and heretical relationships in dynamodb",
   "main": "index.js",
   "scripts": {

--- a/src/entity.js
+++ b/src/entity.js
@@ -3222,6 +3222,9 @@ class Entity {
 
     // If keys are not custom, set the prefixes
     if (!keys.pk.isCustom) {
+      if (tableIndex.scope) {
+        pk = `${pk}_${tableIndex.scope}`;
+      }
       keys.pk.prefix = u.formatKeyCasing(pk, tableIndex.pk.casing);
     }
 
@@ -3842,6 +3845,7 @@ class Entity {
       let indexName = index.index || TableIndex;
       let indexType =
         typeof index.type === "string" ? index.type : IndexTypes.isolated;
+      let indexScope = index.scope || "";
       if (indexType === "clustered") {
         clusteredIndexes.add(accessPattern);
       }
@@ -3940,14 +3944,15 @@ class Entity {
         }
       }
 
-      let definition = {
+      let definition= {
         pk,
         sk,
-        collection,
         hasSk,
+        collection,
         customFacets,
-        index: indexName,
         type: indexType,
+        index: indexName,
+        scope: indexScope,
       };
 
       indexHasSubCollections[indexName] =

--- a/src/entity.js
+++ b/src/entity.js
@@ -3222,8 +3222,8 @@ class Entity {
 
     // If keys are not custom, set the prefixes
     if (!keys.pk.isCustom) {
-      if (tableIndex.namespace) {
-        pk = `${pk}_${tableIndex.namespace}`;
+      if (tableIndex.scope) {
+        pk = `${pk}_${tableIndex.scope}`;
       }
       keys.pk.prefix = u.formatKeyCasing(pk, tableIndex.pk.casing);
     }
@@ -3845,7 +3845,7 @@ class Entity {
       let indexName = index.index || TableIndex;
       let indexType =
         typeof index.type === "string" ? index.type : IndexTypes.isolated;
-      let indexNamespace = index.namespace || "";
+      let indexScope = index.scope || "";
       if (indexType === "clustered") {
         clusteredIndexes.add(accessPattern);
       }
@@ -3952,7 +3952,7 @@ class Entity {
         customFacets,
         type: indexType,
         index: indexName,
-        namespace: indexNamespace,
+        scope: indexScope,
       };
 
       indexHasSubCollections[indexName] =

--- a/src/entity.js
+++ b/src/entity.js
@@ -3222,8 +3222,8 @@ class Entity {
 
     // If keys are not custom, set the prefixes
     if (!keys.pk.isCustom) {
-      if (tableIndex.scope) {
-        pk = `${pk}_${tableIndex.scope}`;
+      if (tableIndex.namespace) {
+        pk = `${pk}_${tableIndex.namespace}`;
       }
       keys.pk.prefix = u.formatKeyCasing(pk, tableIndex.pk.casing);
     }
@@ -3845,7 +3845,7 @@ class Entity {
       let indexName = index.index || TableIndex;
       let indexType =
         typeof index.type === "string" ? index.type : IndexTypes.isolated;
-      let indexScope = index.scope || "";
+      let indexNamespace = index.namespace || "";
       if (indexType === "clustered") {
         clusteredIndexes.add(accessPattern);
       }
@@ -3952,7 +3952,7 @@ class Entity {
         customFacets,
         type: indexType,
         index: indexName,
-        scope: indexScope,
+        namespace: indexNamespace,
       };
 
       indexHasSubCollections[indexName] =

--- a/src/service.js
+++ b/src/service.js
@@ -584,6 +584,7 @@ class Service {
     let pkFieldMatch = definition.pk.field === providedIndex.pk.field;
     let pkFacetLengthMatch =
       definition.pk.facets.length === providedIndex.pk.facets.length;
+    let scopeMatch = definition.scope === providedIndex.scope;
     let mismatchedFacetLabels = [];
     let collectionDifferences = [];
     let definitionIndexName = u.formatIndexNameForDisplay(definition.index);
@@ -629,6 +630,16 @@ class Service {
         });
         break;
       }
+    }
+
+    if (!scopeMatch) {
+      collectionDifferences.push(
+          `The index scope value provided "${
+              providedIndex.scope || "undefined"
+          }" does not match established index scope value "${
+              definition.scope || "undefined"
+          }" on index "${providedIndexName}". Index scope options must match across all entities participating in a collection`,
+      );
     }
 
     if (!isCustomMatchPK) {

--- a/src/service.js
+++ b/src/service.js
@@ -584,7 +584,7 @@ class Service {
     let pkFieldMatch = definition.pk.field === providedIndex.pk.field;
     let pkFacetLengthMatch =
       definition.pk.facets.length === providedIndex.pk.facets.length;
-    let scopeMatch = definition.scope === providedIndex.scope;
+    let namespaceMatch = definition.namespace === providedIndex.namespace;
     let mismatchedFacetLabels = [];
     let collectionDifferences = [];
     let definitionIndexName = u.formatIndexNameForDisplay(definition.index);
@@ -632,13 +632,13 @@ class Service {
       }
     }
 
-    if (!scopeMatch) {
+    if (!namespaceMatch) {
       collectionDifferences.push(
-          `The index scope value provided "${
-              providedIndex.scope || "undefined"
-          }" does not match established index scope value "${
-              definition.scope || "undefined"
-          }" on index "${providedIndexName}". Index scope options must match across all entities participating in a collection`,
+          `The index namespace value provided "${
+              providedIndex.namespace || "undefined"
+          }" does not match established index namespace value "${
+              definition.namespace || "undefined"
+          }" on index "${providedIndexName}". Index namespace options must match across all entities participating in a collection`,
       );
     }
 

--- a/src/service.js
+++ b/src/service.js
@@ -584,7 +584,7 @@ class Service {
     let pkFieldMatch = definition.pk.field === providedIndex.pk.field;
     let pkFacetLengthMatch =
       definition.pk.facets.length === providedIndex.pk.facets.length;
-    let namespaceMatch = definition.namespace === providedIndex.namespace;
+    let scopeMatch = definition.scope === providedIndex.scope;
     let mismatchedFacetLabels = [];
     let collectionDifferences = [];
     let definitionIndexName = u.formatIndexNameForDisplay(definition.index);
@@ -632,13 +632,13 @@ class Service {
       }
     }
 
-    if (!namespaceMatch) {
+    if (!scopeMatch) {
       collectionDifferences.push(
-          `The index namespace value provided "${
-              providedIndex.namespace || "undefined"
-          }" does not match established index namespace value "${
-              definition.namespace || "undefined"
-          }" on index "${providedIndexName}". Index namespace options must match across all entities participating in a collection`,
+          `The index scope value provided "${
+              providedIndex.scope || "undefined"
+          }" does not match established index scope value "${
+              definition.scope || "undefined"
+          }" on index "${providedIndexName}". Index scope options must match across all entities participating in a collection`,
       );
     }
 

--- a/src/validations.js
+++ b/src/validations.js
@@ -119,7 +119,7 @@ const Index = {
           enum: ["string", "number"],
           required: false,
         },
-        namespace: {
+        scope: {
           type: "string",
           required: false,
         }

--- a/src/validations.js
+++ b/src/validations.js
@@ -119,7 +119,7 @@ const Index = {
           enum: ["string", "number"],
           required: false,
         },
-        scope: {
+        namespace: {
           type: "string",
           required: false,
         }

--- a/src/validations.js
+++ b/src/validations.js
@@ -119,6 +119,10 @@ const Index = {
           enum: ["string", "number"],
           required: false,
         },
+        scope: {
+          type: "string",
+          required: false,
+        }
       },
     },
     sk: {

--- a/test/ts_connected.entity.spec.ts
+++ b/test/ts_connected.entity.spec.ts
@@ -2573,9 +2573,9 @@ describe('field translation', () => {
   });
 });
 
-describe('index scope', () => {
+describe('index namespace', () => {
   const serviceName = uuid();
-  const withScope = new Entity(
+  const withNamespace = new Entity(
       {
         model: {
           entity: serviceName,
@@ -2601,7 +2601,7 @@ describe('index scope', () => {
         },
         indexes: {
           test: {
-            scope: 'scope1',
+            namespace: 'namespace1',
             pk: {
               field: "pk",
               composite: ["prop1"],
@@ -2613,7 +2613,7 @@ describe('index scope', () => {
           },
           reverse: {
             index: 'gsi1pk-gsi1sk-index',
-            scope: 'scope2',
+            namespace: 'namespace2',
             pk: {
               field: "gsi1pk",
               composite: ["prop2"],
@@ -2628,7 +2628,7 @@ describe('index scope', () => {
       { table: "electro", client }
   );
 
-  const withoutScope = new Entity(
+  const withoutNamespace = new Entity(
       {
         model: {
           entity: serviceName,
@@ -2679,71 +2679,71 @@ describe('index scope', () => {
       { table: "electro", client }
   );
 
-  it('should add scope value to all keys', () => {
-    const getParams = withScope.get({prop1: 'abc', prop2: 'def'}).params();
-    expect(getParams.Key.pk).to.equal('$test_scope1#prop1_abc');
+  it('should add namespace value to all keys', () => {
+    const getParams = withNamespace.get({prop1: 'abc', prop2: 'def'}).params();
+    expect(getParams.Key.pk).to.equal('$test_namespace1#prop1_abc');
 
-    const queryParams = withScope.query.test({prop1: 'abc'}).params();
-    expect(queryParams.ExpressionAttributeValues[':pk']).to.equal('$test_scope1#prop1_abc');
+    const queryParams = withNamespace.query.test({prop1: 'abc'}).params();
+    expect(queryParams.ExpressionAttributeValues[':pk']).to.equal('$test_namespace1#prop1_abc');
 
-    const queryParams2 = withScope.query.reverse({prop2: 'def'}).params();
-    expect(queryParams2.ExpressionAttributeValues[':pk']).to.equal('$test_scope2#prop2_def');
+    const queryParams2 = withNamespace.query.reverse({prop2: 'def'}).params();
+    expect(queryParams2.ExpressionAttributeValues[':pk']).to.equal('$test_namespace2#prop2_def');
 
-    const scanParams = withScope.scan.params();
-    expect(scanParams.ExpressionAttributeValues[':pk']).to.equal('$test_scope1#prop1_');
+    const scanParams = withNamespace.scan.params();
+    expect(scanParams.ExpressionAttributeValues[':pk']).to.equal('$test_namespace1#prop1_');
 
-    const deleteParams = withScope.delete({prop1: 'abc', prop2: 'def'}).params();
-    expect(deleteParams.Key.pk).to.equal('$test_scope1#prop1_abc');
+    const deleteParams = withNamespace.delete({prop1: 'abc', prop2: 'def'}).params();
+    expect(deleteParams.Key.pk).to.equal('$test_namespace1#prop1_abc');
 
-    const removeParams = withScope.remove({prop1: 'abc', prop2: 'def'}).params();
-    expect(removeParams.Key.pk).to.equal('$test_scope1#prop1_abc');
+    const removeParams = withNamespace.remove({prop1: 'abc', prop2: 'def'}).params();
+    expect(removeParams.Key.pk).to.equal('$test_namespace1#prop1_abc');
 
-    const updateParams = withScope.update({prop1: 'abc', prop2: 'def'}).set({prop3: 'ghi'}).params();
-    expect(updateParams.Key.pk).to.equal('$test_scope1#prop1_abc');
+    const updateParams = withNamespace.update({prop1: 'abc', prop2: 'def'}).set({prop3: 'ghi'}).params();
+    expect(updateParams.Key.pk).to.equal('$test_namespace1#prop1_abc');
 
-    const patchParams = withScope.patch({prop1: 'abc', prop2: 'def'}).set({prop3: 'ghi'}).params();
-    expect(patchParams.Key.pk).to.equal('$test_scope1#prop1_abc');
+    const patchParams = withNamespace.patch({prop1: 'abc', prop2: 'def'}).set({prop3: 'ghi'}).params();
+    expect(patchParams.Key.pk).to.equal('$test_namespace1#prop1_abc');
 
-    const putParams = withScope.put({prop1: 'abc', prop2: 'def'}).params();
-    expect(putParams.Item.pk).to.equal('$test_scope1#prop1_abc');
+    const putParams = withNamespace.put({prop1: 'abc', prop2: 'def'}).params();
+    expect(putParams.Item.pk).to.equal('$test_namespace1#prop1_abc');
 
-    const createParams = withScope.create({prop1: 'abc', prop2: 'def'}).params();
-    expect(createParams.Item.pk).to.equal('$test_scope1#prop1_abc');
+    const createParams = withNamespace.create({prop1: 'abc', prop2: 'def'}).params();
+    expect(createParams.Item.pk).to.equal('$test_namespace1#prop1_abc');
 
-    const upsertParams = withScope.upsert({prop1: 'abc', prop2: 'def'}).set({prop3: 'ghi'}).params();
-    expect(upsertParams.Key.pk).to.equal('$test_scope1#prop1_abc');
+    const upsertParams = withNamespace.upsert({prop1: 'abc', prop2: 'def'}).set({prop3: 'ghi'}).params();
+    expect(upsertParams.Key.pk).to.equal('$test_namespace1#prop1_abc');
 
-    const batchGetParams = withScope.get([{prop1: 'abc', prop2: 'def'}]).params();
-    expect(batchGetParams[0].RequestItems.electro.Keys[0].pk).to.equal('$test_scope1#prop1_abc');
+    const batchGetParams = withNamespace.get([{prop1: 'abc', prop2: 'def'}]).params();
+    expect(batchGetParams[0].RequestItems.electro.Keys[0].pk).to.equal('$test_namespace1#prop1_abc');
 
-    const batchDeleteParams = withScope.delete([{prop1: 'abc', prop2: 'def'}]).params();
-    expect(batchDeleteParams[0].RequestItems.electro[0].DeleteRequest.Key.pk).to.equal('$test_scope1#prop1_abc');
+    const batchDeleteParams = withNamespace.delete([{prop1: 'abc', prop2: 'def'}]).params();
+    expect(batchDeleteParams[0].RequestItems.electro[0].DeleteRequest.Key.pk).to.equal('$test_namespace1#prop1_abc');
 
-    const batchPutParams = withScope.put([{prop1: 'abc', prop2: 'def'}]).params();
-    expect(batchPutParams[0].RequestItems.electro[0].PutRequest.Item.pk).to.equal('$test_scope1#prop1_abc');
+    const batchPutParams = withNamespace.put([{prop1: 'abc', prop2: 'def'}]).params();
+    expect(batchPutParams[0].RequestItems.electro[0].PutRequest.Item.pk).to.equal('$test_namespace1#prop1_abc');
 
-    const keys = withScope.conversions.fromComposite.toKeys({prop1: 'abc', prop2: 'def'});
-    expect(keys.pk).to.equal('$test_scope1#prop1_abc');
-    expect(keys.gsi1pk).to.equal('$test_scope2#prop2_def');
+    const keys = withNamespace.conversions.fromComposite.toKeys({prop1: 'abc', prop2: 'def'});
+    expect(keys.pk).to.equal('$test_namespace1#prop1_abc');
+    expect(keys.gsi1pk).to.equal('$test_namespace2#prop2_def');
 
-    const keysComposite = withScope.conversions.fromKeys.toComposite(keys);
+    const keysComposite = withNamespace.conversions.fromKeys.toComposite(keys);
     expect(keysComposite).to.deep.equal({prop1: 'abc', prop2: 'def'});
 
-    const indexKeys = withScope.conversions.byAccessPattern.test.fromComposite.toKeys({prop1: 'abc', prop2: 'def'});
-    expect(indexKeys.pk).to.equal('$test_scope1#prop1_abc');
+    const indexKeys = withNamespace.conversions.byAccessPattern.test.fromComposite.toKeys({prop1: 'abc', prop2: 'def'});
+    expect(indexKeys.pk).to.equal('$test_namespace1#prop1_abc');
 
-    const indexKeysComposite = withScope.conversions.byAccessPattern.test.fromKeys.toComposite(indexKeys);
+    const indexKeysComposite = withNamespace.conversions.byAccessPattern.test.fromKeys.toComposite(indexKeys);
     expect(indexKeysComposite).to.deep.equal({prop1: 'abc', prop2: 'def'});
 
-    const reverseKeys = withScope.conversions.byAccessPattern.reverse.fromComposite.toKeys({prop1: 'abc', prop2: 'def'});
-    expect(reverseKeys.gsi1pk).to.equal('$test_scope2#prop2_def');
-    expect(keys.pk).to.equal('$test_scope1#prop1_abc');
+    const reverseKeys = withNamespace.conversions.byAccessPattern.reverse.fromComposite.toKeys({prop1: 'abc', prop2: 'def'});
+    expect(reverseKeys.gsi1pk).to.equal('$test_namespace2#prop2_def');
+    expect(keys.pk).to.equal('$test_namespace1#prop1_abc');
 
-    const reverseKeysComposite = withScope.conversions.byAccessPattern.reverse.fromKeys.toComposite(reverseKeys);
+    const reverseKeysComposite = withNamespace.conversions.byAccessPattern.reverse.fromKeys.toComposite(reverseKeys);
     expect(reverseKeysComposite).to.deep.equal({prop1: 'abc', prop2: 'def'});
   });
 
-  it('should query scoped indexes without issue', async () => {
+  it('should query namespaced indexes without issue', async () => {
     const prop1 = uuid();
     const prop2 = uuid();
 
@@ -2760,72 +2760,72 @@ describe('index scope', () => {
     };
 
     const [
-      scopeRecord,
-      withoutScopeRecord
+      namespaceRecord,
+      withoutNamespaceRecord
     ] = await Promise.all([
-        withScope.create(record1).go(),
-        withoutScope.create(record2).go(),
+        withNamespace.create(record1).go(),
+        withoutNamespace.create(record2).go(),
     ]);
 
-    expect(scopeRecord.data).to.deep.equal(record1);
-    expect(withoutScopeRecord.data).to.deep.equal(record2);
+    expect(namespaceRecord.data).to.deep.equal(record1);
+    expect(withoutNamespaceRecord.data).to.deep.equal(record2);
 
-    const scopeGet = await withScope.get({prop1, prop2}).go();
-    expect(scopeGet.data).to.deep.equal(record1);
+    const namespaceGet = await withNamespace.get({prop1, prop2}).go();
+    expect(namespaceGet.data).to.deep.equal(record1);
 
-    const withoutScopeGet = await withoutScope.get({prop1, prop2}).go();
-    expect(withoutScopeGet.data).to.deep.equal(record2);
+    const withoutNamespaceGet = await withoutNamespace.get({prop1, prop2}).go();
+    expect(withoutNamespaceGet.data).to.deep.equal(record2);
 
-    const scopeQuery = await withScope.query.test({prop1}).go();
-    expect(scopeQuery.data).to.deep.equal([record1]);
+    const namespaceQuery = await withNamespace.query.test({prop1}).go();
+    expect(namespaceQuery.data).to.deep.equal([record1]);
 
-    const withoutScopeQuery = await withoutScope.query.test({prop1}).go();
-    expect(withoutScopeQuery.data).to.deep.equal([record2]);
+    const withoutNamespaceQuery = await withoutNamespace.query.test({prop1}).go();
+    expect(withoutNamespaceQuery.data).to.deep.equal([record2]);
 
-    const reverseScopeQuery = await withScope.query.reverse({prop2}).go();
-    expect(reverseScopeQuery.data).to.deep.equal([record1]);
+    const reverseNamespaceQuery = await withNamespace.query.reverse({prop2}).go();
+    expect(reverseNamespaceQuery.data).to.deep.equal([record1]);
 
-    const reverseWithoutScopeQuery = await withoutScope.query.reverse({prop2}).go();
-    expect(reverseWithoutScopeQuery.data).to.deep.equal([record2]);
+    const reverseWithoutNamespaceQuery = await withoutNamespace.query.reverse({prop2}).go();
+    expect(reverseWithoutNamespaceQuery.data).to.deep.equal([record2]);
 
-    const batchGetScopeRecords = await withScope.get([{prop1, prop2}]).go();
-    expect(batchGetScopeRecords.data).to.deep.equal([record1]);
+    const batchGetNamespaceRecords = await withNamespace.get([{prop1, prop2}]).go();
+    expect(batchGetNamespaceRecords.data).to.deep.equal([record1]);
 
-    const batchGetWithoutScopeRecords = await withoutScope.get([{prop1, prop2}]).go();
-    expect(batchGetWithoutScopeRecords.data).to.deep.equal([record2]);
+    const batchGetWithoutNamespaceRecords = await withoutNamespace.get([{prop1, prop2}]).go();
+    expect(batchGetWithoutNamespaceRecords.data).to.deep.equal([record2]);
 
-    const updatedScopeRecord = await withScope.update({prop1, prop2}).set({prop4: ['updated1']}).go({response: 'all_new'});
-    expect(updatedScopeRecord.data).to.deep.equal({
+    const updatedNamespaceRecord = await withNamespace.update({prop1, prop2}).set({prop4: ['updated1']}).go({response: 'all_new'});
+    expect(updatedNamespaceRecord.data).to.deep.equal({
       ...record1,
       prop4: ['updated1'],
     });
 
-    const updatedWithoutScopeRecord = await withoutScope.update({prop1, prop2}).set({prop4: ['updated2']}).go({response: 'all_new'});
-    expect(updatedWithoutScopeRecord.data).to.deep.equal({
+    const updatedWithoutNamespaceRecord = await withoutNamespace.update({prop1, prop2}).set({prop4: ['updated2']}).go({response: 'all_new'});
+    expect(updatedWithoutNamespaceRecord.data).to.deep.equal({
       ...record2,
       prop4: ['updated2'],
     });
 
-    const patchedScopeRecord = await withScope.patch({prop1, prop2}).append({prop4: ['patched1']}).go({response: 'all_new'});
-    expect(patchedScopeRecord.data).to.deep.equal({
+    const patchedNamespaceRecord = await withNamespace.patch({prop1, prop2}).append({prop4: ['patched1']}).go({response: 'all_new'});
+    expect(patchedNamespaceRecord.data).to.deep.equal({
       ...record1,
       prop4: ['updated1', 'patched1'],
     });
 
-    const patchedWithoutScopeRecord = await withoutScope.patch({prop1, prop2}).append({prop4: ['patched2']}).go({response: 'all_new'});
-    expect(patchedWithoutScopeRecord.data).to.deep.equal({
+    const patchedWithoutNamespaceRecord = await withoutNamespace.patch({prop1, prop2}).append({prop4: ['patched2']}).go({response: 'all_new'});
+    expect(patchedWithoutNamespaceRecord.data).to.deep.equal({
       ...record2,
       prop4: ['updated2', 'patched2'],
     });
 
-    const upsertedScopeRecord = await withScope.upsert({prop1, prop2}).append({prop4: ['upserted1']}).go({response: 'all_new'});
-    expect(upsertedScopeRecord.data).to.deep.equal({
+    const upsertedNamespaceRecord = await withNamespace.upsert({prop1, prop2}).append({prop4: ['upserted1']}).go({response: 'all_new'});
+    expect(upsertedNamespaceRecord.data).to.deep.equal({
       ...record1,
       prop4: ['updated1', 'patched1', 'upserted1'],
     });
 
-    const upsertedWithoutScopeRecord = await withoutScope.upsert({prop1, prop2}).append({prop4: ['upserted2']}).go({response: 'all_new'});
-    expect(upsertedWithoutScopeRecord.data).to.deep.equal({
+    const upsertedWithoutNamespaceRecord = await withoutNamespace.upsert({prop1, prop2}).append({prop4: ['upserted2']}).go({response: 'all_new'});
+    expect(upsertedWithoutNamespaceRecord.data).to.deep.equal({
       ...record2,
       prop4: ['updated2', 'patched2', 'upserted2'],
     });

--- a/test/ts_connected.entity.spec.ts
+++ b/test/ts_connected.entity.spec.ts
@@ -2573,9 +2573,9 @@ describe('field translation', () => {
   });
 });
 
-describe('index namespace', () => {
+describe('index scope', () => {
   const serviceName = uuid();
-  const withNamespace = new Entity(
+  const withScope = new Entity(
       {
         model: {
           entity: serviceName,
@@ -2601,7 +2601,7 @@ describe('index namespace', () => {
         },
         indexes: {
           test: {
-            namespace: 'namespace1',
+            scope: 'scope1',
             pk: {
               field: "pk",
               composite: ["prop1"],
@@ -2613,7 +2613,7 @@ describe('index namespace', () => {
           },
           reverse: {
             index: 'gsi1pk-gsi1sk-index',
-            namespace: 'namespace2',
+            scope: 'scope2',
             pk: {
               field: "gsi1pk",
               composite: ["prop2"],
@@ -2628,7 +2628,7 @@ describe('index namespace', () => {
       { table: "electro", client }
   );
 
-  const withoutNamespace = new Entity(
+  const withoutScope = new Entity(
       {
         model: {
           entity: serviceName,
@@ -2679,71 +2679,71 @@ describe('index namespace', () => {
       { table: "electro", client }
   );
 
-  it('should add namespace value to all keys', () => {
-    const getParams = withNamespace.get({prop1: 'abc', prop2: 'def'}).params();
-    expect(getParams.Key.pk).to.equal('$test_namespace1#prop1_abc');
+  it('should add scope value to all keys', () => {
+    const getParams = withScope.get({prop1: 'abc', prop2: 'def'}).params();
+    expect(getParams.Key.pk).to.equal('$test_scope1#prop1_abc');
 
-    const queryParams = withNamespace.query.test({prop1: 'abc'}).params();
-    expect(queryParams.ExpressionAttributeValues[':pk']).to.equal('$test_namespace1#prop1_abc');
+    const queryParams = withScope.query.test({prop1: 'abc'}).params();
+    expect(queryParams.ExpressionAttributeValues[':pk']).to.equal('$test_scope1#prop1_abc');
 
-    const queryParams2 = withNamespace.query.reverse({prop2: 'def'}).params();
-    expect(queryParams2.ExpressionAttributeValues[':pk']).to.equal('$test_namespace2#prop2_def');
+    const queryParams2 = withScope.query.reverse({prop2: 'def'}).params();
+    expect(queryParams2.ExpressionAttributeValues[':pk']).to.equal('$test_scope2#prop2_def');
 
-    const scanParams = withNamespace.scan.params();
-    expect(scanParams.ExpressionAttributeValues[':pk']).to.equal('$test_namespace1#prop1_');
+    const scanParams = withScope.scan.params();
+    expect(scanParams.ExpressionAttributeValues[':pk']).to.equal('$test_scope1#prop1_');
 
-    const deleteParams = withNamespace.delete({prop1: 'abc', prop2: 'def'}).params();
-    expect(deleteParams.Key.pk).to.equal('$test_namespace1#prop1_abc');
+    const deleteParams = withScope.delete({prop1: 'abc', prop2: 'def'}).params();
+    expect(deleteParams.Key.pk).to.equal('$test_scope1#prop1_abc');
 
-    const removeParams = withNamespace.remove({prop1: 'abc', prop2: 'def'}).params();
-    expect(removeParams.Key.pk).to.equal('$test_namespace1#prop1_abc');
+    const removeParams = withScope.remove({prop1: 'abc', prop2: 'def'}).params();
+    expect(removeParams.Key.pk).to.equal('$test_scope1#prop1_abc');
 
-    const updateParams = withNamespace.update({prop1: 'abc', prop2: 'def'}).set({prop3: 'ghi'}).params();
-    expect(updateParams.Key.pk).to.equal('$test_namespace1#prop1_abc');
+    const updateParams = withScope.update({prop1: 'abc', prop2: 'def'}).set({prop3: 'ghi'}).params();
+    expect(updateParams.Key.pk).to.equal('$test_scope1#prop1_abc');
 
-    const patchParams = withNamespace.patch({prop1: 'abc', prop2: 'def'}).set({prop3: 'ghi'}).params();
-    expect(patchParams.Key.pk).to.equal('$test_namespace1#prop1_abc');
+    const patchParams = withScope.patch({prop1: 'abc', prop2: 'def'}).set({prop3: 'ghi'}).params();
+    expect(patchParams.Key.pk).to.equal('$test_scope1#prop1_abc');
 
-    const putParams = withNamespace.put({prop1: 'abc', prop2: 'def'}).params();
-    expect(putParams.Item.pk).to.equal('$test_namespace1#prop1_abc');
+    const putParams = withScope.put({prop1: 'abc', prop2: 'def'}).params();
+    expect(putParams.Item.pk).to.equal('$test_scope1#prop1_abc');
 
-    const createParams = withNamespace.create({prop1: 'abc', prop2: 'def'}).params();
-    expect(createParams.Item.pk).to.equal('$test_namespace1#prop1_abc');
+    const createParams = withScope.create({prop1: 'abc', prop2: 'def'}).params();
+    expect(createParams.Item.pk).to.equal('$test_scope1#prop1_abc');
 
-    const upsertParams = withNamespace.upsert({prop1: 'abc', prop2: 'def'}).set({prop3: 'ghi'}).params();
-    expect(upsertParams.Key.pk).to.equal('$test_namespace1#prop1_abc');
+    const upsertParams = withScope.upsert({prop1: 'abc', prop2: 'def'}).set({prop3: 'ghi'}).params();
+    expect(upsertParams.Key.pk).to.equal('$test_scope1#prop1_abc');
 
-    const batchGetParams = withNamespace.get([{prop1: 'abc', prop2: 'def'}]).params();
-    expect(batchGetParams[0].RequestItems.electro.Keys[0].pk).to.equal('$test_namespace1#prop1_abc');
+    const batchGetParams = withScope.get([{prop1: 'abc', prop2: 'def'}]).params();
+    expect(batchGetParams[0].RequestItems.electro.Keys[0].pk).to.equal('$test_scope1#prop1_abc');
 
-    const batchDeleteParams = withNamespace.delete([{prop1: 'abc', prop2: 'def'}]).params();
-    expect(batchDeleteParams[0].RequestItems.electro[0].DeleteRequest.Key.pk).to.equal('$test_namespace1#prop1_abc');
+    const batchDeleteParams = withScope.delete([{prop1: 'abc', prop2: 'def'}]).params();
+    expect(batchDeleteParams[0].RequestItems.electro[0].DeleteRequest.Key.pk).to.equal('$test_scope1#prop1_abc');
 
-    const batchPutParams = withNamespace.put([{prop1: 'abc', prop2: 'def'}]).params();
-    expect(batchPutParams[0].RequestItems.electro[0].PutRequest.Item.pk).to.equal('$test_namespace1#prop1_abc');
+    const batchPutParams = withScope.put([{prop1: 'abc', prop2: 'def'}]).params();
+    expect(batchPutParams[0].RequestItems.electro[0].PutRequest.Item.pk).to.equal('$test_scope1#prop1_abc');
 
-    const keys = withNamespace.conversions.fromComposite.toKeys({prop1: 'abc', prop2: 'def'});
-    expect(keys.pk).to.equal('$test_namespace1#prop1_abc');
-    expect(keys.gsi1pk).to.equal('$test_namespace2#prop2_def');
+    const keys = withScope.conversions.fromComposite.toKeys({prop1: 'abc', prop2: 'def'});
+    expect(keys.pk).to.equal('$test_scope1#prop1_abc');
+    expect(keys.gsi1pk).to.equal('$test_scope2#prop2_def');
 
-    const keysComposite = withNamespace.conversions.fromKeys.toComposite(keys);
+    const keysComposite = withScope.conversions.fromKeys.toComposite(keys);
     expect(keysComposite).to.deep.equal({prop1: 'abc', prop2: 'def'});
 
-    const indexKeys = withNamespace.conversions.byAccessPattern.test.fromComposite.toKeys({prop1: 'abc', prop2: 'def'});
-    expect(indexKeys.pk).to.equal('$test_namespace1#prop1_abc');
+    const indexKeys = withScope.conversions.byAccessPattern.test.fromComposite.toKeys({prop1: 'abc', prop2: 'def'});
+    expect(indexKeys.pk).to.equal('$test_scope1#prop1_abc');
 
-    const indexKeysComposite = withNamespace.conversions.byAccessPattern.test.fromKeys.toComposite(indexKeys);
+    const indexKeysComposite = withScope.conversions.byAccessPattern.test.fromKeys.toComposite(indexKeys);
     expect(indexKeysComposite).to.deep.equal({prop1: 'abc', prop2: 'def'});
 
-    const reverseKeys = withNamespace.conversions.byAccessPattern.reverse.fromComposite.toKeys({prop1: 'abc', prop2: 'def'});
-    expect(reverseKeys.gsi1pk).to.equal('$test_namespace2#prop2_def');
-    expect(keys.pk).to.equal('$test_namespace1#prop1_abc');
+    const reverseKeys = withScope.conversions.byAccessPattern.reverse.fromComposite.toKeys({prop1: 'abc', prop2: 'def'});
+    expect(reverseKeys.gsi1pk).to.equal('$test_scope2#prop2_def');
+    expect(keys.pk).to.equal('$test_scope1#prop1_abc');
 
-    const reverseKeysComposite = withNamespace.conversions.byAccessPattern.reverse.fromKeys.toComposite(reverseKeys);
+    const reverseKeysComposite = withScope.conversions.byAccessPattern.reverse.fromKeys.toComposite(reverseKeys);
     expect(reverseKeysComposite).to.deep.equal({prop1: 'abc', prop2: 'def'});
   });
 
-  it('should query namespaced indexes without issue', async () => {
+  it('should query scoped indexes without issue', async () => {
     const prop1 = uuid();
     const prop2 = uuid();
 
@@ -2760,72 +2760,72 @@ describe('index namespace', () => {
     };
 
     const [
-      namespaceRecord,
-      withoutNamespaceRecord
+      scopeRecord,
+      withoutScopeRecord
     ] = await Promise.all([
-        withNamespace.create(record1).go(),
-        withoutNamespace.create(record2).go(),
+        withScope.create(record1).go(),
+        withoutScope.create(record2).go(),
     ]);
 
-    expect(namespaceRecord.data).to.deep.equal(record1);
-    expect(withoutNamespaceRecord.data).to.deep.equal(record2);
+    expect(scopeRecord.data).to.deep.equal(record1);
+    expect(withoutScopeRecord.data).to.deep.equal(record2);
 
-    const namespaceGet = await withNamespace.get({prop1, prop2}).go();
-    expect(namespaceGet.data).to.deep.equal(record1);
+    const scopeGet = await withScope.get({prop1, prop2}).go();
+    expect(scopeGet.data).to.deep.equal(record1);
 
-    const withoutNamespaceGet = await withoutNamespace.get({prop1, prop2}).go();
-    expect(withoutNamespaceGet.data).to.deep.equal(record2);
+    const withoutScopeGet = await withoutScope.get({prop1, prop2}).go();
+    expect(withoutScopeGet.data).to.deep.equal(record2);
 
-    const namespaceQuery = await withNamespace.query.test({prop1}).go();
-    expect(namespaceQuery.data).to.deep.equal([record1]);
+    const scopeQuery = await withScope.query.test({prop1}).go();
+    expect(scopeQuery.data).to.deep.equal([record1]);
 
-    const withoutNamespaceQuery = await withoutNamespace.query.test({prop1}).go();
-    expect(withoutNamespaceQuery.data).to.deep.equal([record2]);
+    const withoutScopeQuery = await withoutScope.query.test({prop1}).go();
+    expect(withoutScopeQuery.data).to.deep.equal([record2]);
 
-    const reverseNamespaceQuery = await withNamespace.query.reverse({prop2}).go();
-    expect(reverseNamespaceQuery.data).to.deep.equal([record1]);
+    const reverseScopeQuery = await withScope.query.reverse({prop2}).go();
+    expect(reverseScopeQuery.data).to.deep.equal([record1]);
 
-    const reverseWithoutNamespaceQuery = await withoutNamespace.query.reverse({prop2}).go();
-    expect(reverseWithoutNamespaceQuery.data).to.deep.equal([record2]);
+    const reverseWithoutScopeQuery = await withoutScope.query.reverse({prop2}).go();
+    expect(reverseWithoutScopeQuery.data).to.deep.equal([record2]);
 
-    const batchGetNamespaceRecords = await withNamespace.get([{prop1, prop2}]).go();
-    expect(batchGetNamespaceRecords.data).to.deep.equal([record1]);
+    const batchGetScopeRecords = await withScope.get([{prop1, prop2}]).go();
+    expect(batchGetScopeRecords.data).to.deep.equal([record1]);
 
-    const batchGetWithoutNamespaceRecords = await withoutNamespace.get([{prop1, prop2}]).go();
-    expect(batchGetWithoutNamespaceRecords.data).to.deep.equal([record2]);
+    const batchGetWithoutScopeRecords = await withoutScope.get([{prop1, prop2}]).go();
+    expect(batchGetWithoutScopeRecords.data).to.deep.equal([record2]);
 
-    const updatedNamespaceRecord = await withNamespace.update({prop1, prop2}).set({prop4: ['updated1']}).go({response: 'all_new'});
-    expect(updatedNamespaceRecord.data).to.deep.equal({
+    const updatedScopeRecord = await withScope.update({prop1, prop2}).set({prop4: ['updated1']}).go({response: 'all_new'});
+    expect(updatedScopeRecord.data).to.deep.equal({
       ...record1,
       prop4: ['updated1'],
     });
 
-    const updatedWithoutNamespaceRecord = await withoutNamespace.update({prop1, prop2}).set({prop4: ['updated2']}).go({response: 'all_new'});
-    expect(updatedWithoutNamespaceRecord.data).to.deep.equal({
+    const updatedWithoutScopeRecord = await withoutScope.update({prop1, prop2}).set({prop4: ['updated2']}).go({response: 'all_new'});
+    expect(updatedWithoutScopeRecord.data).to.deep.equal({
       ...record2,
       prop4: ['updated2'],
     });
 
-    const patchedNamespaceRecord = await withNamespace.patch({prop1, prop2}).append({prop4: ['patched1']}).go({response: 'all_new'});
-    expect(patchedNamespaceRecord.data).to.deep.equal({
+    const patchedScopeRecord = await withScope.patch({prop1, prop2}).append({prop4: ['patched1']}).go({response: 'all_new'});
+    expect(patchedScopeRecord.data).to.deep.equal({
       ...record1,
       prop4: ['updated1', 'patched1'],
     });
 
-    const patchedWithoutNamespaceRecord = await withoutNamespace.patch({prop1, prop2}).append({prop4: ['patched2']}).go({response: 'all_new'});
-    expect(patchedWithoutNamespaceRecord.data).to.deep.equal({
+    const patchedWithoutScopeRecord = await withoutScope.patch({prop1, prop2}).append({prop4: ['patched2']}).go({response: 'all_new'});
+    expect(patchedWithoutScopeRecord.data).to.deep.equal({
       ...record2,
       prop4: ['updated2', 'patched2'],
     });
 
-    const upsertedNamespaceRecord = await withNamespace.upsert({prop1, prop2}).append({prop4: ['upserted1']}).go({response: 'all_new'});
-    expect(upsertedNamespaceRecord.data).to.deep.equal({
+    const upsertedScopeRecord = await withScope.upsert({prop1, prop2}).append({prop4: ['upserted1']}).go({response: 'all_new'});
+    expect(upsertedScopeRecord.data).to.deep.equal({
       ...record1,
       prop4: ['updated1', 'patched1', 'upserted1'],
     });
 
-    const upsertedWithoutNamespaceRecord = await withoutNamespace.upsert({prop1, prop2}).append({prop4: ['upserted2']}).go({response: 'all_new'});
-    expect(upsertedWithoutNamespaceRecord.data).to.deep.equal({
+    const upsertedWithoutScopeRecord = await withoutScope.upsert({prop1, prop2}).append({prop4: ['upserted2']}).go({response: 'all_new'});
+    expect(upsertedWithoutScopeRecord.data).to.deep.equal({
       ...record2,
       prop4: ['updated2', 'patched2', 'upserted2'],
     });

--- a/test/ts_connected.service.spec.ts
+++ b/test/ts_connected.service.spec.ts
@@ -3168,7 +3168,7 @@ describe("composite compatibility", () => {
   });
 });
 
-describe('namespace compatibility', () => {
+describe('scope compatibility', () => {
   const entity1 = new Entity(
       {
         model: {
@@ -3190,7 +3190,7 @@ describe('namespace compatibility', () => {
         indexes: {
           test: {
             collection: 'testing',
-            namespace: 'subtest',
+            scope: 'subtest',
             pk: {
               field: "pk",
               composite: ["prop1"],
@@ -3226,7 +3226,7 @@ describe('namespace compatibility', () => {
         indexes: {
           test: {
             collection: 'testing',
-            namespace: 'subtestz',
+            scope: 'subtestz',
             pk: {
               field: "pk",
               composite: ["prop1"],
@@ -3262,7 +3262,7 @@ describe('namespace compatibility', () => {
         indexes: {
           test: {
             collection: 'testing',
-            namespace: 'subtest',
+            scope: 'subtest',
             pk: {
               field: "pk",
               composite: ["prop1"],
@@ -3277,7 +3277,7 @@ describe('namespace compatibility', () => {
       { table: "electro", client }
   );
 
-  it('should throw an error when namespaces are not compatible between collection members', () => {
+  it('should throw an error when scopes are not compatible between collection members', () => {
     let result: any = null;
     let threw = false;
     try {
@@ -3288,10 +3288,10 @@ describe('namespace compatibility', () => {
     }
 
     expect(threw).to.be.true;
-    expect(result.message).to.equal(`Validation Error while joining entity, "entity2". The index namespace value provided "subtestz" does not match established index namespace value "subtest" on index "(Primary Index)". Index namespace options must match across all entities participating in a collection - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#join`)
+    expect(result.message).to.equal(`Validation Error while joining entity, "entity2". The index scope value provided "subtestz" does not match established index scope value "subtest" on index "(Primary Index)". Index scope options must match across all entities participating in a collection - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#join`)
   });
 
-  it('should not throw when namespaces are compatible between collection members', () => {
+  it('should not throw when scopes are compatible between collection members', () => {
     let result: any = null;
     let threw = false;
     try {
@@ -3305,7 +3305,7 @@ describe('namespace compatibility', () => {
     expect(result).to.be.null;
   });
 
-  it('should query when namespaces are compatible between collection members', async () => {
+  it('should query when scopes are compatible between collection members', async () => {
     const service = new Service({ entity1, entity3 });
     const prop1 = uuid();
     const prop2 = uuid();

--- a/test/ts_connected.service.spec.ts
+++ b/test/ts_connected.service.spec.ts
@@ -3167,3 +3167,187 @@ describe("composite compatibility", () => {
     two();
   });
 });
+
+describe('scope compatibility', () => {
+  const entity1 = new Entity(
+      {
+        model: {
+          entity: "entity1",
+          service: 'test',
+          version: "1",
+        },
+        attributes: {
+          prop1: {
+            type: "string",
+          },
+          prop2: {
+            type: "string",
+          },
+          prop3: {
+            type: "string",
+          }
+        },
+        indexes: {
+          test: {
+            collection: 'testing',
+            scope: 'subtest',
+            pk: {
+              field: "pk",
+              composite: ["prop1"],
+            },
+            sk: {
+              field: "sk",
+              composite: ["prop2"],
+            },
+          },
+        },
+      },
+      { table: "electro", client }
+  );
+
+  const entity2 = new Entity(
+      {
+        model: {
+          entity: "entity2",
+          service: 'test',
+          version: "1",
+        },
+        attributes: {
+          prop1: {
+            type: "string",
+          },
+          prop2: {
+            type: "string",
+          },
+          prop3: {
+            type: "string",
+          }
+        },
+        indexes: {
+          test: {
+            collection: 'testing',
+            scope: 'subtestz',
+            pk: {
+              field: "pk",
+              composite: ["prop1"],
+            },
+            sk: {
+              field: "sk",
+              composite: ["prop2"],
+            },
+          },
+        },
+      },
+      { table: "electro", client }
+  );
+
+  const entity3 = new Entity(
+      {
+        model: {
+          entity: "entity3",
+          service: 'test',
+          version: "1",
+        },
+        attributes: {
+          prop1: {
+            type: "string",
+          },
+          prop2: {
+            type: "string",
+          },
+          prop3: {
+            type: "string",
+          }
+        },
+        indexes: {
+          test: {
+            collection: 'testing',
+            scope: 'subtest',
+            pk: {
+              field: "pk",
+              composite: ["prop1"],
+            },
+            sk: {
+              field: "sk",
+              composite: ["prop2"],
+            },
+          },
+        },
+      },
+      { table: "electro", client }
+  );
+
+  it('should throw an error when scopes are not compatible between collection members', () => {
+    let result: any = null;
+    let threw = false;
+    try {
+      new Service({ entity1, entity2 });
+    } catch(err) {
+      threw = true;
+      result = err;
+    }
+
+    expect(threw).to.be.true;
+    expect(result.message).to.equal(`Validation Error while joining entity, "entity2". The index scope value provided "subtestz" does not match established index scope value "subtest" on index "(Primary Index)". Index scope options must match across all entities participating in a collection - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#join`)
+  });
+
+  it('should not throw when scopes are compatible between collection members', () => {
+    let result: any = null;
+    let threw = false;
+    try {
+      new Service({ entity1, entity3 });
+    } catch(err) {
+      threw = true;
+      result = err;
+    }
+
+    expect(threw).to.be.false;
+    expect(result).to.be.null;
+  });
+
+  it('should query when scopes are compatible between collection members', async () => {
+    const service = new Service({ entity1, entity3 });
+    const prop1 = uuid();
+    const prop2 = uuid();
+    const record1 = {
+      prop1,
+      prop2,
+      prop3: uuid(),
+    };
+
+    const record2 = {
+      prop1,
+      prop2,
+      prop3: uuid(),
+    };
+
+    const record3 = {
+      prop1,
+      prop2,
+      prop3: uuid(),
+    };
+
+    await Promise.all([
+        entity1.put(record1).go(),
+        entity2.put(record2).go(),
+        entity3.put(record3).go(),
+    ]);
+
+    const params = service.collections.testing({ prop1 }).params();
+    expect(params.ExpressionAttributeValues[':pk']).to.equal(`$test_subtest#prop1_${prop1}`);
+
+    const collectionResponse = await service.collections.testing({ prop1 }).go();
+    expect(collectionResponse.data).to.deep.equal({
+        entity1: [record1],
+        entity3: [record3],
+    });
+
+    const entity2Params = entity2.query.test({ prop1 }).params();
+    expect(entity2Params.ExpressionAttributeValues[':pk']).to.equal(`$test_subtestz#prop1_${prop1}`);
+
+    const entity2Response = await entity2.query.test({ prop1 }).go();
+    console.log(JSON.stringify({entity2Params, entity2Response}, null, 4));
+    expect(entity2Response.data.length).to.equal(1);
+    expect(entity2Response.data[0]).to.deep.equal(record2);
+  })
+});

--- a/test/ts_connected.service.spec.ts
+++ b/test/ts_connected.service.spec.ts
@@ -3168,7 +3168,7 @@ describe("composite compatibility", () => {
   });
 });
 
-describe('scope compatibility', () => {
+describe('namespace compatibility', () => {
   const entity1 = new Entity(
       {
         model: {
@@ -3190,7 +3190,7 @@ describe('scope compatibility', () => {
         indexes: {
           test: {
             collection: 'testing',
-            scope: 'subtest',
+            namespace: 'subtest',
             pk: {
               field: "pk",
               composite: ["prop1"],
@@ -3226,7 +3226,7 @@ describe('scope compatibility', () => {
         indexes: {
           test: {
             collection: 'testing',
-            scope: 'subtestz',
+            namespace: 'subtestz',
             pk: {
               field: "pk",
               composite: ["prop1"],
@@ -3262,7 +3262,7 @@ describe('scope compatibility', () => {
         indexes: {
           test: {
             collection: 'testing',
-            scope: 'subtest',
+            namespace: 'subtest',
             pk: {
               field: "pk",
               composite: ["prop1"],
@@ -3277,7 +3277,7 @@ describe('scope compatibility', () => {
       { table: "electro", client }
   );
 
-  it('should throw an error when scopes are not compatible between collection members', () => {
+  it('should throw an error when namespaces are not compatible between collection members', () => {
     let result: any = null;
     let threw = false;
     try {
@@ -3288,10 +3288,10 @@ describe('scope compatibility', () => {
     }
 
     expect(threw).to.be.true;
-    expect(result.message).to.equal(`Validation Error while joining entity, "entity2". The index scope value provided "subtestz" does not match established index scope value "subtest" on index "(Primary Index)". Index scope options must match across all entities participating in a collection - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#join`)
+    expect(result.message).to.equal(`Validation Error while joining entity, "entity2". The index namespace value provided "subtestz" does not match established index namespace value "subtest" on index "(Primary Index)". Index namespace options must match across all entities participating in a collection - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#join`)
   });
 
-  it('should not throw when scopes are compatible between collection members', () => {
+  it('should not throw when namespaces are compatible between collection members', () => {
     let result: any = null;
     let threw = false;
     try {
@@ -3305,7 +3305,7 @@ describe('scope compatibility', () => {
     expect(result).to.be.null;
   });
 
-  it('should query when scopes are compatible between collection members', async () => {
+  it('should query when namespaces are compatible between collection members', async () => {
     const service = new Service({ entity1, entity3 });
     const prop1 = uuid();
     const prop2 = uuid();

--- a/www/src/pages/en/modeling/indexes.mdx
+++ b/www/src/pages/en/modeling/indexes.mdx
@@ -425,6 +425,145 @@ In the example below, we are configuring the casing ElectroDB will use individua
 |    `upper`    | Will convert the key to uppercase prior it its use     |
 |    `none`     | Will not perform any casing changes when building keys |
 
+### Index Scoping
+
+When designing your indexes with Single Table Design, you may find yourself in a situation where the composite attributes of one entity's partition key are the same as another entity. While in most cases this would be a deliberate choice, made to more easily query across entities via [collections](en/modeling/collections), there are times when you might desire further isolation between entities. This is most commonly encountered when the partition key of both entities are defined with an empty composite array. When futher isolation between entities on an index is necessary, you can use the `scope` property on your index to directly impact how records are partitioned.
+
+The example below demonstrates how to use the `scope` property to isolate records on an index. In this example, the `organization` entity and the `user` entity both have a partition key of `pk` with an empty composite array. This means that both entities will share the same partition key, and will be stored in the same partition. This is not ideal, as it means that a query for a user will also return records for an organization. To isolate these entities, we can use the `scope` property on the index to further isolate the partition key for each entity.
+
+```typescript
+const organization = new Entity({
+  model: {
+    entity: "organization",
+    service: "taskapp",
+    version: "1"
+  },
+  attributes: {
+    organizationId: {
+      type: "string"
+    },
+  },
+  indexes: {
+    myIndex: {
+      scope: "org", // <--- Scope is set to unique value "org"
+      pk: {
+        field: "pk",
+        composite: []
+      },
+      sk: {
+        field: "sk",
+        composite: ["organizationId"]
+      }
+    }
+  }
+}, { table: "your_table_name" });
+
+const user = new Entity({
+  model: {
+    entity: "user",
+    service: "taskapp",
+    version: "1"
+  },
+  attributes: {
+    userId: {
+      type: "string"
+    },
+  },
+  indexes: {
+    myIndex: {
+      scope: "user", // <--- Scope is set to unique value "user"
+      pk: {
+        field: "pk",
+        composite: []
+      },
+      sk: {
+        field: "sk",
+        composite: ["userId"]
+      }
+    }
+  }
+}, { table: "your_table_name" });
+```
+
+Without the use of `scope`, both entities would share the same partition key and would be stored in the same partition. With the use of `scope`, each entity will have a unique partition key and will be stored in a separate partition.
+
+#### Without Scope
+
+Without a `scope` value, notice the partition key value at ExpressionAttributeValues[':pk'] is the same for both queries. This occurs when composite attribute array for a partition key matches between entities. Keep in mind that, in most cases, this is desirable because it helps enable querying across entities via [collections](/en/modeling/collections). However, in some cases, this may not be desirable which is why the `scope` property exists.
+
+```typescript
+organization.query.myIndex({organizationId: '123'}).go();
+
+// {
+//     "KeyConditionExpression": "#pk = :pk and #sk1 = :sk1",
+//     "TableName": "your_table_name",
+//     "ExpressionAttributeNames": {
+//         "#pk": "pk",
+//         "#sk1": "sk"
+//     },
+//     "ExpressionAttributeValues": {
+//         ":pk": "$taskapp",
+//         ":sk1": "$organization_1#organizationid_org123"
+//     }
+// }
+```
+
+```typescript
+user.query.myIndex({userId: '456'}).go();
+
+// {
+//     "KeyConditionExpression": "#pk = :pk and #sk1 = :sk1",
+//     "TableName": "your_table_name",
+//     "ExpressionAttributeNames": {
+//         "#pk": "pk",
+//         "#sk1": "sk"
+//     },
+//     "ExpressionAttributeValues": {
+//         ":pk": "$taskapp",
+//         ":sk1": "$organization_1#organizationid_org123"
+//     }
+// }
+```
+
+#### With Scope
+
+Notice the value at ExpressionAttributeValues[':pk'] now contains the `scope` value that was provided by the user on the index definition.
+
+```typescript
+organization.query.myIndex({organizationId: '123'}).go();
+// {
+//     "KeyConditionExpression": "#pk = :pk and #sk1 = :sk1",
+//     "TableName": "your_table_name",
+//     "ExpressionAttributeNames": {
+//         "#pk": "pk",
+//         "#sk1": "sk"
+//     },
+//     "ExpressionAttributeValues": {
+//         ":pk": "$taskapp_org",
+//         ":sk1": "$organization_1#organizationid_org123"
+//     }
+// }
+```
+
+```typescript
+user.query.myIndex({userId: '456'}).go();
+
+// {
+//     "KeyConditionExpression": "#pk = :pk and #sk1 = :sk1",
+//     "TableName": "your_table_name",
+//     "ExpressionAttributeNames": {
+//         "#pk": "pk",
+//         "#sk1": "sk"
+//     },
+//     "ExpressionAttributeValues": {
+//         ":pk": "$taskapp_user",
+//         ":sk1": "$organization_1#organizationid_org123"
+//     }
+// }
+```
+
+[![Try it out!](https://img.shields.io/badge/electrodb-try_out_this_example_›-%23f9bd00?style=for-the-badge&logo=amazondynamodb&labelColor=1a212a)](https://electrodb.fun/?#code/JYWwDg9gTgLgBAbzgUQHY2DAnnAvnAMyghDgCIBTAGwoGMZiATAIzIG4AoD2iVAZ3gBXPhSh84AXjioKAdxTpMWABQIOcOCAiNqALkTqNcCouz6yw0WQA0hjSKgA3YLQrmYAQz4BrD2DA2dnCOonzAvOYAjGSGuLYaHjAMwMyCMBR8+mpGcOkeIACSjFlBGthgbuQCUMCoAOYxOXFBllBFJTllWBXm1bUNQc050HUeqMAAXonhqO0GnbndlWR99Y1GQ0bENB2d5curA03xRgTAYjAAcvmV2XtLvclrgycaVF5XN7s5+481z8cghQQB5gFRvkZflUnkcNq84IxEhQABLnCjFeb3HrQ-4NeG4WInWo6AAeGQhrUymJyYG8EJyZ2oGLItMCCw0PHAEDC6X0AG0yCMxpNprwimQALrwnIAehlcHetG8cAgBDgAANaF5+uq4GBiBVYDgdAQPIIqDBxDAIAqILJRFqRKU8NK4D56adgEzet42ezOZAeZUBa1xVLnRo5XBBP4HV4MnBvBQcMwKARoBQ3R5nPUZTHERhcwBHQSiLD9CNwR39cwxw3rJovILbcnUozEigk8x1MKRWkAWh7wEiPn7HZJfppdLbDK9VGZQ77vtdHJIgcwwbIeUKjElK7gUcYEAy6CrAAsxnVM0mcNX6nBZGeTFmc3U82AC-0ZSWyxX2VXtXqcxUF4CgbDgZ1Nhyd0Z09b1yEXHxJ06ANuQ3fkyBbcCyALFE0V3cN-yjOs4xEcQbzgVN0ygTM+GzL982mYtSygct6krO86lrWMoAbDZBliDg4kQXIPGYHZyCwCBBCgAB9TxxIoWTUBuMg8AASk4bheAEXIKHyIpJHIAAVfSQAAISoUsYh4fghAcQypDIABVBxIgAJgAZhsnT4CFcYpgwMVGCMshTNoM8AGFoACbS7LgFtQpALAACUIBoHz4rOC5rhATMnIAKQ8JVMt094BFy-LyAAQUYGheLi3TgVBKhQoAK2K7wADoPDq0QAAF0gingoDALrmEmUr4Fw1EaJCpz3IABncyJ+0WgB2Nboi4SlDC6sA0lUIJtyKeFQ0YeF-JFILZgu5t0ooeFsoqm54XKz48vhZqwXhGb8JOXB1L2uoIGUTSdocPgup-Vi9spVQrsCmYikB4HQfBjhKWhlisD2ls+FUE6LoSh7UY0caKBge0TGUIIED+ubzCWla1oANjIKDEAZ9EmeW9yto5wwgfJkGwbYIA)
+
 ### Attributes as Indexes
 
 It may be the case that an index field is also an attribute. For example, if a table was created with a Primary Index partition key of `accountId`, and that same field is used to store the `accountId` value used by the application. The following are a few examples of how to model that schema with ElectroDB:

--- a/www/src/pages/en/modeling/indexes.mdx
+++ b/www/src/pages/en/modeling/indexes.mdx
@@ -425,13 +425,13 @@ In the example below, we are configuring the casing ElectroDB will use individua
 |    `upper`    | Will convert the key to uppercase prior it its use     |
 |    `none`     | Will not perform any casing changes when building keys |
 
-### Index Namespacing
+### Index Scoping
 
-When designing your indexes with Single Table Design, you may find yourself in a situation where the composite attributes of one entity's partition key are the same as another entity. While in most cases this would be a deliberate choice, made to more easily query across entities via [collections](en/modeling/collections), there are times when you might desire further isolation between entities. This scenario is most commonly encountered when the partition key of both entities are defined with an empty composite array. When futher isolation between entities on an index is necessary, you can use the `namespace` property on your index to directly impact how records are partitioned.
+When designing your indexes with Single Table Design, you may find yourself in a situation where the composite attributes of one entity's partition key are the same as another entity. While in most cases this would be a deliberate choice, made to more easily query across entities via [collections](en/modeling/collections), there are times when you might desire further isolation between entities. This scenario is most commonly encountered when the partition key of both entities are defined with an empty composite array. When futher isolation between entities on an index is necessary, you can use the `scope` property on your index to directly impact how records are partitioned.
 
-> Note: the `namespace` concept came from an RFC that was thoughtfully put forward by [@Sam3d](https://github.com/sam3d) in [Issue #290](https://github.com/tywalch/electrodb/issues/290), which can be read for further context. Thank you, Brooke for your contribution!
+> Note: the `scope` concept came from an RFC that was thoughtfully put forward by [@Sam3d](https://github.com/sam3d) in [Issue #290](https://github.com/tywalch/electrodb/issues/290), which can be read for further context. Thank you, Brooke for your contribution!
 
-The example below demonstrates how to use the `namespace` property to isolate records on an index. In this example, the `organization` entity and the `user` entity both have a partition key of `pk` with an empty composite array. This means that both entities will share the same partition key, and will be stored in the same partition. This is not ideal, as it means that a query for a user will also return records for an organization. To isolate these entities, we can use the `namespace` property on the index to further isolate the partition key for each entity.
+The example below demonstrates how to use the `scope` property to isolate records on an index. In this example, the `organization` entity and the `user` entity both have a partition key of `pk` with an empty composite array. This means that both entities will share the same partition key, and will be stored in the same partition. This is not ideal, as it means that a query for a user will also return records for an organization. To isolate these entities, we can use the `scope` property on the index to further isolate the partition key for each entity.
 
 ```typescript
 const organization = new Entity({
@@ -447,7 +447,7 @@ const organization = new Entity({
   },
   indexes: {
     myIndex: {
-      namespace: "org", // <--- Namespace is set to unique value "org"
+      scope: "org", // <--- Scope is set to unique value "org"
       pk: {
         field: "pk",
         composite: []
@@ -473,7 +473,7 @@ const user = new Entity({
   },
   indexes: {
     myIndex: {
-      namespace: "user", // <--- Namespace is set to unique value "user"
+      scope: "user", // <--- Scope is set to unique value "user"
       pk: {
         field: "pk",
         composite: []
@@ -487,11 +487,11 @@ const user = new Entity({
 }, { table: "your_table_name" });
 ```
 
-Without the use of `namespace`, both entities would share the same partition key and would be stored in the same partition. With the use of `namespace`, each entity will have a unique partition key and will be stored in a separate partition.
+Without the use of `scope`, both entities would share the same partition key and would be stored in the same partition. With the use of `scope`, each entity will have a unique partition key and will be stored in a separate partition.
 
-#### Without Namespace
+#### Without Scope
 
-Without a `namespace` value, notice the partition key value at ExpressionAttributeValues[':pk'] is the same for both queries. This occurs when composite attribute array for a partition key matches between entities. Keep in mind that, in most cases, this is desirable because it helps enable querying across entities via [collections](/en/modeling/collections). However, in some cases, this may not be desirable which is why the `namespace` property exists.
+Without a `scope` value, notice the partition key value at ExpressionAttributeValues[':pk'] is the same for both queries. This occurs when composite attribute array for a partition key matches between entities. Keep in mind that, in most cases, this is desirable because it helps enable querying across entities via [collections](/en/modeling/collections). However, in some cases, this may not be desirable which is why the `scope` property exists.
 
 ```typescript
 organization.query.myIndex({organizationId: '123'}).go();
@@ -527,9 +527,9 @@ user.query.myIndex({userId: '456'}).go();
 // }
 ```
 
-#### With Namespace
+#### With Scope
 
-Notice the value at ExpressionAttributeValues[':pk'] now contains the `namespace` value that was provided by the user on the index definition.
+Notice the value at ExpressionAttributeValues[':pk'] now contains the `scope` value that was provided by the user on the index definition.
 
 ```typescript
 organization.query.myIndex({organizationId: '123'}).go();

--- a/www/src/pages/en/modeling/indexes.mdx
+++ b/www/src/pages/en/modeling/indexes.mdx
@@ -427,9 +427,9 @@ In the example below, we are configuring the casing ElectroDB will use individua
 
 ### Index Scoping
 
-When designing your indexes with Single Table Design, you may find yourself in a situation where the composite attributes of one entity's partition key are the same as another entity. While in most cases this would be a deliberate choice, made to more easily query across entities via [collections](en/modeling/collections), there are times when you might desire further isolation between entities. This is most commonly encountered when the partition key of both entities are defined with an empty composite array. When futher isolation between entities on an index is necessary, you can use the `scope` property on your index to directly impact how records are partitioned.
+When designing your indexes with Single Table Design, you may find yourself in a situation where the composite attributes of one entity's partition key are the same as another entity. While in most cases this would be a deliberate choice, made to more easily query across entities via [collections](en/modeling/collections), there are times when you might desire further isolation between entities. This is most commonly encountered when the partition key of both entities are defined with an empty composite array. When futher isolation between entities on an index is necessary, you can use the `namespace` property on your index to directly impact how records are partitioned.
 
-The example below demonstrates how to use the `scope` property to isolate records on an index. In this example, the `organization` entity and the `user` entity both have a partition key of `pk` with an empty composite array. This means that both entities will share the same partition key, and will be stored in the same partition. This is not ideal, as it means that a query for a user will also return records for an organization. To isolate these entities, we can use the `scope` property on the index to further isolate the partition key for each entity.
+The example below demonstrates how to use the `namespace` property to isolate records on an index. In this example, the `organization` entity and the `user` entity both have a partition key of `pk` with an empty composite array. This means that both entities will share the same partition key, and will be stored in the same partition. This is not ideal, as it means that a query for a user will also return records for an organization. To isolate these entities, we can use the `namespace` property on the index to further isolate the partition key for each entity.
 
 ```typescript
 const organization = new Entity({
@@ -445,7 +445,7 @@ const organization = new Entity({
   },
   indexes: {
     myIndex: {
-      scope: "org", // <--- Scope is set to unique value "org"
+      namespace: "org", // <--- Namespace is set to unique value "org"
       pk: {
         field: "pk",
         composite: []
@@ -471,7 +471,7 @@ const user = new Entity({
   },
   indexes: {
     myIndex: {
-      scope: "user", // <--- Scope is set to unique value "user"
+      namespace: "user", // <--- Namespace is set to unique value "user"
       pk: {
         field: "pk",
         composite: []
@@ -485,11 +485,11 @@ const user = new Entity({
 }, { table: "your_table_name" });
 ```
 
-Without the use of `scope`, both entities would share the same partition key and would be stored in the same partition. With the use of `scope`, each entity will have a unique partition key and will be stored in a separate partition.
+Without the use of `namespace`, both entities would share the same partition key and would be stored in the same partition. With the use of `namespace`, each entity will have a unique partition key and will be stored in a separate partition.
 
-#### Without Scope
+#### Without Namespace
 
-Without a `scope` value, notice the partition key value at ExpressionAttributeValues[':pk'] is the same for both queries. This occurs when composite attribute array for a partition key matches between entities. Keep in mind that, in most cases, this is desirable because it helps enable querying across entities via [collections](/en/modeling/collections). However, in some cases, this may not be desirable which is why the `scope` property exists.
+Without a `namespace` value, notice the partition key value at ExpressionAttributeValues[':pk'] is the same for both queries. This occurs when composite attribute array for a partition key matches between entities. Keep in mind that, in most cases, this is desirable because it helps enable querying across entities via [collections](/en/modeling/collections). However, in some cases, this may not be desirable which is why the `namespace` property exists.
 
 ```typescript
 organization.query.myIndex({organizationId: '123'}).go();
@@ -525,9 +525,9 @@ user.query.myIndex({userId: '456'}).go();
 // }
 ```
 
-#### With Scope
+#### With Namespace
 
-Notice the value at ExpressionAttributeValues[':pk'] now contains the `scope` value that was provided by the user on the index definition.
+Notice the value at ExpressionAttributeValues[':pk'] now contains the `namespace` value that was provided by the user on the index definition.
 
 ```typescript
 organization.query.myIndex({organizationId: '123'}).go();

--- a/www/src/pages/en/modeling/indexes.mdx
+++ b/www/src/pages/en/modeling/indexes.mdx
@@ -425,9 +425,11 @@ In the example below, we are configuring the casing ElectroDB will use individua
 |    `upper`    | Will convert the key to uppercase prior it its use     |
 |    `none`     | Will not perform any casing changes when building keys |
 
-### Index Scoping
+### Index Namespacing
 
-When designing your indexes with Single Table Design, you may find yourself in a situation where the composite attributes of one entity's partition key are the same as another entity. While in most cases this would be a deliberate choice, made to more easily query across entities via [collections](en/modeling/collections), there are times when you might desire further isolation between entities. This is most commonly encountered when the partition key of both entities are defined with an empty composite array. When futher isolation between entities on an index is necessary, you can use the `namespace` property on your index to directly impact how records are partitioned.
+When designing your indexes with Single Table Design, you may find yourself in a situation where the composite attributes of one entity's partition key are the same as another entity. While in most cases this would be a deliberate choice, made to more easily query across entities via [collections](en/modeling/collections), there are times when you might desire further isolation between entities. This scenario is most commonly encountered when the partition key of both entities are defined with an empty composite array. When futher isolation between entities on an index is necessary, you can use the `namespace` property on your index to directly impact how records are partitioned.
+
+> Note: the `namespace` concept came from an RFC that was thoughtfully put forward by [@Sam3d](https://github.com/sam3d) in [Issue #290](https://github.com/tywalch/electrodb/issues/290), which can be read for further context. Thank you, Brooke for your contribution!
 
 The example below demonstrates how to use the `namespace` property to isolate records on an index. In this example, the `organization` entity and the `user` entity both have a partition key of `pk` with an empty composite array. This means that both entities will share the same partition key, and will be stored in the same partition. This is not ideal, as it means that a query for a user will also return records for an organization. To isolate these entities, we can use the `namespace` property on the index to further isolate the partition key for each entity.
 


### PR DESCRIPTION
This property allows users to further isolate partition keys beyond just `service` participation. This implements an RFC that was thoughtfully put forward by [@Sam3d](https://github.com/sam3d) in [Issue #290](https://github.com/tywalch/electrodb/issues/290).