### PR TITLE
Adds optional `condition` fn  to index defs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3658,6 +3658,7 @@ export interface Schema<A extends string, F extends string, C extends string> {
       readonly scope?: string;
       readonly type?: "clustered" | "isolated";
       readonly collection?: AccessPatternCollection<C>;
+      readonly condition?: (composite: Record<string, unknown>) => boolean;
       readonly pk: {
         readonly casing?: "upper" | "lower" | "none" | "default";
         readonly field: string;

--- a/src/entity.js
+++ b/src/entity.js
@@ -2412,22 +2412,22 @@ class Entity {
           (!attribute || !attribute.indexes || attribute.indexes.length === 0)
         ) {
           /*
-            // this should be considered but is likely overkill at best and unexpected at worst.
-            // It also is likely symbolic of a deeper issue. That said maybe it could be helpful
-            // in the future? It is unclear, if this were added, whether this should get the
-            // default value and then call the setter on the defaultValue. That would at least
-            // make parity between upsert and a create (without including the attribute) and then
-            // an "update"
+						// this should be considered but is likely overkill at best and unexpected at worst.
+						// It also is likely symbolic of a deeper issue. That said maybe it could be helpful
+						// in the future? It is unclear, if this were added, whether this should get the
+						// default value and then call the setter on the defaultValue. That would at least
+						// make parity between upsert and a create (without including the attribute) and then
+						// an "update"
 
-            const defaultValue = attribute.default();
-            const valueIsNumber = typeof value === 'number';
-            const resolvedDefaultValue  = typeof defaultValue === 'number' ? defaultValue : 0;
-            if (operation === UpsertOperations.subtract && valueIsNumber) {
-                value = resolvedDefaultValue - value;
-            } else if (operation === UpsertOperations.add && valueIsNumber) {
-                value = resolvedDefaultValue + value;
-          // }
-        */
+						const defaultValue = attribute.default();
+						const valueIsNumber = typeof value === 'number';
+						const resolvedDefaultValue  = typeof defaultValue === 'number' ? defaultValue : 0;
+						if (operation === UpsertOperations.subtract && valueIsNumber) {
+							value = resolvedDefaultValue - value;
+						} else if (operation === UpsertOperations.add && valueIsNumber) {
+							value = resolvedDefaultValue + value;
+					// }
+					*/
           update.set(field, value, ItemOperations.ifNotExists);
         } else {
           updateProxy.performOperation({
@@ -2945,7 +2945,6 @@ class Entity {
     if (!completeFacets.indexes.includes(updateIndex)) {
       completeFacets.indexes.push(updateIndex);
     }
-
     let composedKeys = this._makePutKeysFromAttributes(completeFacets.indexes, {
       ...keyAttributes,
       ...setAttributes,
@@ -2995,6 +2994,7 @@ class Entity {
       completeFacets.impactedIndexTypes,
       { ...set, ...keyAttributes },
     );
+
     let updatedKeys = {};
     let deletedKeys = [];
     let indexKey = {};
@@ -3046,12 +3046,12 @@ class Entity {
       if (attributes[attribute] !== undefined) {
         facets[attribute] = attributes[attribute];
         indexes.forEach(({ index, type }) => {
-          impactedIndexes[index] = impactedIndexes[index] || {};
-          impactedIndexes[index][type] = impactedIndexes[index][type] || [];
-          impactedIndexes[index][type].push(attribute);
-          impactedIndexTypes[index] = impactedIndexTypes[index] || {};
-          impactedIndexTypes[index][type] =
-            this.model.translations.keys[index][type];
+            impactedIndexes[index] = impactedIndexes[index] || {};
+            impactedIndexes[index][type] = impactedIndexes[index][type] || [];
+            impactedIndexes[index][type].push(attribute);
+            impactedIndexTypes[index] = impactedIndexTypes[index] || {};
+            impactedIndexTypes[index][type] =
+                this.model.translations.keys[index][type];
         });
       }
     }

--- a/src/errors.js
+++ b/src/errors.js
@@ -211,6 +211,12 @@ const ErrorCodes = {
     name: "DuplicateUpdateCompositesProvided",
     sym: ErrorCode,
   },
+  InvalidIndexCondition: {
+    code: 2011,
+    section: "invalid-index-option",
+    name: "InvalidIndexOption",
+    sym: ErrorCode,
+  },
   InvalidAttribute: {
     code: 3001,
     section: "invalid-attribute",

--- a/src/validations.js
+++ b/src/validations.js
@@ -174,6 +174,11 @@ const Index = {
       enum: ["clustered", "isolated"],
       required: false,
     },
+    condition: {
+      type: "any",
+      required: false,
+      format: "isFunction",
+    }
   },
 };
 

--- a/test/ts_connected.entity.spec.ts
+++ b/test/ts_connected.entity.spec.ts
@@ -1,5 +1,5 @@
 import { DocumentClient, PutItemInput } from "aws-sdk/clients/dynamodb";
-import { Entity } from "../";
+import { Entity, EntityRecord, createWriteTransaction, ElectroEvent } from "../";
 import { expect } from "chai";
 import { v4 as uuid } from "uuid";
 const u = require("../src/util");
@@ -20,6 +20,8 @@ const client = new DocumentClient({
   endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
   region: "us-east-1",
 });
+
+const table = "electro";
 
 describe("conversions", () => {
   const table = "electro";
@@ -2830,6 +2832,444 @@ describe('index scope', () => {
       prop4: ['updated2', 'patched2', 'upserted2'],
     });
   });
+});
+
+describe("conditional indexes", () => {
+  type IndexName = 'sparse1' | 'sparse2' | 'sparse3';
+  type ConditionArguments = {
+    index: IndexName;
+    attr: any;
+  }
+  type TestEntityCondition = (options: ConditionArguments) => boolean;
+  function createTestEntity(fn: TestEntityCondition) {
+    return new Entity(
+        {
+          model: {
+            entity: uuid(),
+            service: uuid(),
+            version: "1",
+          },
+          attributes: {
+            prop1: {
+              type: "string",
+            },
+            prop2: {
+              type: "string",
+            },
+            prop3: {
+              type: "string"
+            },
+            prop4: {
+              type: "string"
+            },
+            prop5: {
+              type: "string"
+            },
+            prop6: {
+              type: "string"
+            },
+            prop7: {
+              type: "string"
+            },
+            prop8: {
+              type: "string"
+            },
+            prop9: {
+              type: "string"
+            }
+          },
+          indexes: {
+            test: {
+              collection: 'testing',
+              pk: {
+                field: "pk",
+                composite: ["prop1"],
+              },
+              sk: {
+                field: "sk",
+                composite: ["prop2"],
+              },
+            },
+            sparse1: {
+              index: 'gsi1pk-gsi1sk-index',
+              condition: (attr) => {
+                return fn({index: 'sparse1', attr});
+              },
+              pk: {
+                field: "gsi1pk",
+                composite: ["prop1"],
+              },
+              sk: {
+                field: "gsi1sk",
+                composite: ["prop2"],
+              },
+            },
+            sparse2: {
+              index: 'gsi2pk-gsi2sk-index',
+              condition: (attr) => {
+                return fn({index: 'sparse2', attr});
+              },
+              pk: {
+                field: 'gsi2pk',
+                composite: ['prop2', 'prop3']
+              },
+              sk: {
+                field: 'gsi2sk',
+                composite: ['prop1', 'prop4', 'prop5']
+              }
+            },
+            sparse3: {
+              index: 'gsi3pk-gsi3sk-index',
+              condition: (attr) => {
+                return fn({index: 'sparse3', attr});
+              },
+              pk: {
+                field: 'gsi3pk',
+                composite: ['prop6', 'prop7']
+              },
+              sk: {
+                field: 'gsi3sk',
+                composite: ['prop8', 'prop9']
+              }
+            }
+          },
+        },
+        {table, client}
+    );
+  }
+
+  function createTestEntityData(): EntityRecord<ReturnType<typeof createTestEntity>> {
+    return {
+      prop1: uuid(),
+      prop2: uuid(),
+      prop3: uuid(),
+      prop4: uuid(),
+      prop5: uuid(),
+      prop6: uuid(),
+      prop7: uuid(),
+      prop8: uuid(),
+      prop9: uuid(),
+    }
+  }
+
+  function createConditionInvocationCollector(result: boolean) {
+    const invocations: ConditionArguments[] = [];
+    const condition: TestEntityCondition = (options) => {
+      invocations.push(options);
+      return result;
+    };
+
+    return {
+      condition,
+      invocations,
+    }
+  }
+
+  function createParamsCollector() {
+    let params: any;
+    return {
+      params: () => params,
+      logger: (event: ElectroEvent) => {
+        if (event.type === 'query') {
+          params = event.params;
+        }
+      }
+    }
+  }
+
+  it('should throw if condition is added to the main table index', () => {
+    expect(() => new Entity({
+      model: {
+        entity: 'test',
+        version: '1',
+        service: 'test',
+      },
+      attributes: {
+        prop1: {
+          type: 'string'
+        },
+        prop2: {
+          type: 'string'
+        }
+      },
+      indexes: {
+        record: {
+          condition: () => true,
+          pk: {
+            field: 'pk',
+            composite: ['prop1']
+          },
+          sk: {
+            field: 'sk',
+            composite: ['prop2']
+          }
+        }
+      }
+    })).to.throw("The index option 'condition' is only allowed on secondary indexes - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#invalid-index-option");
+  });
+
+  it('should prevent thrown exception from partial index update', () => {
+    throw new Error('Test not yet implemented');
+  });
+
+  it('should check the index condition individually on the subject entity', () => {
+    const collector1 = createConditionInvocationCollector(true);
+    const collector2 = createConditionInvocationCollector(false);
+    const data1 = createTestEntityData();
+    const data2 = createTestEntityData();
+    const entity1 = createTestEntity(collector1.condition);
+    const entity2 = createTestEntity(collector2.condition);
+
+    createWriteTransaction({ entity1, entity2 }, ({ entity1, entity2 }) => [
+      entity1.put(data1).commit(),
+      entity2.put(data2).commit(),
+    ]).params();
+
+    for (const invocation of collector1.invocations) {
+      expect(invocation.attr).to.deep.equal(data1);
+    }
+
+    for (const invocation of collector2.invocations) {
+      expect(invocation.attr).to.deep.equal(data2);
+    }
+  });
+
+  type TestCase = [description: string, index: keyof (ReturnType<typeof createTestEntity>['query'])]
+  const tests: TestCase[] = [
+    ["an index with identical pk and sk composite attributes as the main table", 'sparse1'],
+    ["an index with at least the pk and sk composite attributes as the main table", 'sparse2'],
+    ["an index with distinct composite attributes", "sparse3"],
+  ];
+  for (const [description, index] of tests) {
+    describe(`when using a conditional index with ${description}`, () => {
+      for (const shouldWrite of [true, false]) {
+        const prefix = shouldWrite ? 'should' : 'should not';
+        it(`${prefix} write index with provided put attributes`, async () => {
+          const { condition, invocations } = createConditionInvocationCollector(shouldWrite);
+          const { params, logger } = createParamsCollector();
+          const props = createTestEntityData();
+          const entity = createTestEntity(condition);
+          await entity.put(props).go({logger});
+
+          // @ts-ignore
+          const { data } = await entity.query[index](props).go();
+          if (shouldWrite) {
+            expect(data.length).to.equal(1);
+            expect(data[0]).to.deep.equal(props);
+            expect(params().Item[entity.schema.indexes[index].pk.field]).to.not.equal(undefined);
+            expect(params().Item[entity.schema.indexes[index].sk.field]).to.not.equal(undefined);
+          } else {
+            expect(data.length).to.equal(0);
+            expect(params().Item[entity.schema.indexes[index].pk.field]).to.equal(undefined);
+            expect(params().Item[entity.schema.indexes[index].sk.field]).to.equal(undefined);
+          }
+
+          for (const invocation of invocations) {
+            expect(invocation.attr).to.deep.equal(props);
+          }
+        });
+
+        it(`${prefix} write index with provided create attributes`, async () => {
+          const { condition, invocations } = createConditionInvocationCollector(shouldWrite);
+          const { params, logger } = createParamsCollector();
+          const props = createTestEntityData();
+          const entity = createTestEntity(condition);
+          await entity.create(props).go({logger});
+          // @ts-ignore
+          const { data } = await entity.query[index](props).go();
+          if (shouldWrite) {
+            expect(data.length).to.equal(1);
+            expect(data[0]).to.deep.equal(props);
+            expect(params().Item[entity.schema.indexes[index].pk.field]).to.not.equal(undefined);
+            expect(params().Item[entity.schema.indexes[index].sk.field]).to.not.equal(undefined);
+          } else {
+            expect(data.length).to.equal(0);
+            expect(params().Item[entity.schema.indexes[index].pk.field]).to.equal(undefined);
+            expect(params().Item[entity.schema.indexes[index].sk.field]).to.equal(undefined);
+          }
+
+          for (const invocation of invocations) {
+            expect(invocation.attr).to.deep.equal(props);
+          }
+        });
+
+        it(`${prefix} write index with provided upsert attributes`, async () => {
+          const { condition, invocations } = createConditionInvocationCollector(shouldWrite);
+          const { params, logger } = createParamsCollector();
+          const props = createTestEntityData();
+          const entity = createTestEntity(condition);
+          await entity.upsert(props).go({logger});
+          // @ts-ignore
+          const { data } = await entity.query[index](props).go();
+          if (shouldWrite) {
+            expect(data.length).to.equal(1);
+            expect(data[0]).to.deep.equal(props);
+          } else {
+            expect(data.length).to.equal(0);
+          }
+
+          for (const invocation of invocations) {
+            expect(invocation.attr).to.deep.equal(props);
+          }
+        });
+
+        it(`${prefix} write index with provided upsert attributes across multiple method calls`, async () => {
+          const { condition, invocations } = createConditionInvocationCollector(shouldWrite);
+          const { params, logger } = createParamsCollector();
+          const props = createTestEntityData();
+          const entity = createTestEntity(condition);
+          await entity.upsert({})
+              .set({ prop1: props.prop1 })
+              .set({ prop2: props.prop2 })
+              .set({ prop3: props.prop3 })
+              .set({ prop4: props.prop4 })
+              .set({ prop5: props.prop5 })
+              .set({ prop6: props.prop6 })
+              .set({ prop7: props.prop7 })
+              .set({ prop8: props.prop8 })
+              .set({ prop9: props.prop9 })
+              .go({logger});
+          // @ts-ignore
+          const { data } = await entity.query[index](props).go();
+          if (shouldWrite) {
+            expect(data.length).to.equal(1);
+            expect(data[0]).to.deep.equal(props);
+          } else {
+            expect(data.length).to.equal(0);
+          }
+
+          for (const invocation of invocations) {
+            expect(invocation.attr).to.deep.equal(props);
+          }
+        });
+
+        it(`${prefix} write index with provided update attributes`, async () => {
+          const { condition, invocations } = createConditionInvocationCollector(shouldWrite);
+          const { params, logger } = createParamsCollector();
+          const { prop1, prop2, ...props } = createTestEntityData();
+          const entity = createTestEntity(condition);
+          await entity.update({prop1, prop2}).set(props).go({logger});
+          // @ts-ignore
+          const { data } = await entity.query[index]({ prop1, prop2, ...props }).go();
+          if (shouldWrite) {
+            expect(data.length).to.equal(1);
+            expect(data[0]).to.deep.equal({ prop1, prop2, ...props });
+          } else {
+            expect(data.length).to.equal(0);
+          }
+
+          for (const invocation of invocations) {
+            expect(invocation.attr).to.deep.equal({prop1, prop2, ...props});
+          }
+        });
+
+        it(`${prefix} write index with provided update attributes spread across multiple method calls`, async () => {
+          const { condition, invocations } = createConditionInvocationCollector(shouldWrite);
+          const { params, logger } = createParamsCollector();
+          const { prop1, prop2, ...props } = createTestEntityData();
+          const entity = createTestEntity(condition);
+          await entity.update({prop1, prop2}).set({
+            prop3: props.prop3,
+            prop4: props.prop4,
+          }).set({
+            prop5: props.prop5,
+            prop6: props.prop6,
+          }).set({
+            prop7: props.prop7,
+            prop8: props.prop8,
+            prop9: props.prop9,
+          }).go({logger});
+          // @ts-ignore
+          const { data } = await entity.query[index]({ prop1, prop2, ...props }).go();
+          if (shouldWrite) {
+            expect(data.length).to.equal(1);
+            expect(data[0]).to.deep.equal({ prop1, prop2, ...props });
+          } else {
+            expect(data.length).to.equal(0);
+          }
+
+          for (const invocation of invocations) {
+            expect(invocation.attr).to.deep.equal({prop1, prop2, ...props});
+          }
+        });
+
+        it(`${prefix} write index with provided patch attributes`, async () => {
+          const { params, logger } = createParamsCollector();
+          const { prop1, prop2, ...props } = createTestEntityData();
+          let invocations: ConditionArguments[] = [];
+          let allow = false;
+          const condition = (args: ConditionArguments) => {
+            invocations.push(args);
+            return allow;
+          }
+
+          const entity = createTestEntity(condition);
+          // don't write for sure on put, but then yield to test; patch requires an existing item
+          await entity.put({ prop1, prop2 }).go();
+
+          // reset "allow" and reset "invocations"
+          allow = shouldWrite;
+          invocations = [];
+
+          await entity.patch({prop1, prop2}).set(props).go({logger});
+          // @ts-ignore
+          const { data } = await entity.query[index]({ prop1, prop2, ...props }).go();
+          if (shouldWrite) {
+            expect(data.length).to.equal(1);
+            expect(data[0]).to.deep.equal({ prop1, prop2, ...props });
+          } else {
+            expect(data.length).to.equal(0);
+          }
+
+          for (const invocation of invocations) {
+            expect(invocation.attr).to.deep.equal({prop1, prop2, ...props});
+          }
+        });
+
+        it(`${prefix} write index with provided batchPut attributes`, async () => {
+          const { condition, invocations } = createConditionInvocationCollector(shouldWrite);
+          const { params, logger } = createParamsCollector();
+          const props = createTestEntityData();
+          const entity = createTestEntity(condition);
+          await entity.put([props]).go({logger});
+          // @ts-ignore
+          const { data } = await entity.query[index](props).go();
+          if (shouldWrite) {
+            expect(data.length).to.equal(1);
+            expect(data[0]).to.deep.equal(props);
+          } else {
+            expect(data.length).to.equal(0);
+          }
+
+          for (const invocation of invocations) {
+            expect(invocation.attr).to.deep.equal(props);
+          }
+        });
+
+        it(`${prefix} write index with provided transactWrite attributes`, async () => {
+          const { condition, invocations } = createConditionInvocationCollector(shouldWrite);
+          const { params, logger } = createParamsCollector();
+          const props = createTestEntityData();
+          const entity = createTestEntity(condition);
+          await createWriteTransaction({ entity }, ({ entity }) => [
+            entity.put(props).commit(),
+          ]).go({logger});
+          // @ts-ignore
+          const { data } = await entity.query[index](props).go();
+          if (shouldWrite) {
+            expect(data.length).to.equal(1);
+            expect(data[0]).to.deep.equal(props);
+          } else {
+            expect(data.length).to.equal(0);
+          }
+
+          for (const invocation of invocations) {
+            expect(invocation.attr).to.deep.equal(props);
+          }
+        });
+      }
+    });
+  }
 });
 
 

--- a/www/src/pages/en/modeling/indexes.mdx
+++ b/www/src/pages/en/modeling/indexes.mdx
@@ -55,8 +55,9 @@ indexes: {
 | Property       |                 Type                 | Required | Description                                                                                                                                                                                                                                                                                                                                 |
 | -------------- | :----------------------------------: | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `index`        |               `string`               |    no    | Required when the `Index` defined is a _Global/Local Secondary Index_; but is omitted for the table's primary index.                                                                                                                                                                                                                        |
-| `collection`   |         `string`, `string[]`         |    no    | Used when models are joined to a `Service`. When two entities share a `collection` on the same `index`, they can be queried with one request to DynamoDB. The name of the collection should represent what the query would return as a pseudo `Entity`. (see [Collections](/en/modeling/collections) below for more on this functionality). |
+| `collection`   |         `string`, `string[]`         |    no    | Used when models are joined to a `Service`. When two entities share a `collection` on the same `index`, they can be queried with one request to DynamoDB. The name of the collection should represent what the query would return as a pseudo `Entity`; See the page on [Collections](/en/modeling/collections) for more information on this functionality. |
 | `type`         |       `isolated`, `clustered`        |    no    | Allows you to optimize your index for either [entity isolation](/en/modeling/indexes#isolated-indexes) (high volume of records per partition) or (entity relationships)[#clustered-indexes] (high relationship density per partition). When omitted, ElectroDB defaults to `isolation`.                                                     |
+| `condition`    |        `(attr: T) => boolean`        |    no    | A function that accepts all attributes provided every mutation method and returns a boolean value. When provided, ElectroDB will use this function to determine if an index should be be written given a provided set of attributes. This is useful for implementing "sparse" indexes, See the second on [Sparse Indexes](/en/modeling/indexes#sparse-indexes) below for more information on this functionality |
 | `pk`           |               `object`               |   yes    | Configuration for the pk of that index or table                                                                                                                                                                                                                                                                                             |
 | `pk.composite` |              `string[]`              |   yes    | An array that represents the order in which attributes are concatenated to composite attributes the key (see [Composite Attributes](#composing-attributes) below for more on this functionality).                                                                                                                                           |
 | `pk.template`  |               `string`               |    no    | A string that represents the template in which attributes composed to form a key (see [Composite Attribute Templates](#composite-attribute-templates) below for more on this functionality).                                                                                                                                                |
@@ -424,6 +425,35 @@ In the example below, we are configuring the casing ElectroDB will use individua
 |    `lower`    | Will convert the key to lowercase prior it its use     |
 |    `upper`    | Will convert the key to uppercase prior it its use     |
 |    `none`     | Will not perform any casing changes when building keys |
+
+### Sparse Indexes
+
+Sparse indexes are indexes that are only contain a subset of the items on your main table. Sparse indexes are useful when you want to reduce the number of records your query must iterate over to find the records you are looking on a secondary index. By having fewer records on a secondary index, you can improve the performance of your queries and reduce the cost of your table.
+
+ElectroDB manages which secondary indexes are written to your DynamoDB table based on the attributes you provide to your query; this includes adding runtime constraints to ensure consistency between your index key values and its constituent composite attributes. If you wish to prevent an index from being written, you can define a `condition` callback on your index. This callback will be invoked at query-time, passed all attributes set on that mutation, and if it returns `false` the index will not be written to your DynamoDB table.
+
+#### Example
+
+This example shows an index called `myIndex` which has a provided `condition` callback. The `attr` argument contains all attributes provided to the mutation method. This includes all attributes for a `put`, `create`, or `upsert` and/or all attributes `set` on an `update` or `patch`.
+
+```typescript
+{
+  indexes: {
+    myIndex: {
+      index: "gsi1",
+      condition: (attr) => attr.type === "closed"
+      pk: {
+        field: "gsi1pk",
+        composite: ["organizationId"]
+      },
+      sk: {
+        field: "gsi1sk",
+        composite: ["type", "accountId"]
+      }
+    }
+  }
+}
+```
 
 ### Index Scoping
 


### PR DESCRIPTION
To aid users with creating sparse indexes, a `condition` function gives users a mechanism to skip writing keys for a particular secondary index given provided attributes.