### PR TITLE
Fix custom attribute type extraction for union types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3914,51 +3914,53 @@ type PartialDefinedKeys<T> = {
 };
 
 export type ItemAttribute<A extends Attribute> =
-  A["type"] extends OpaquePrimitiveTypeName<infer T>
-    ? T
-    : A["type"] extends CustomAttributeTypeName<infer T>
-    ? T
-    : A["type"] extends infer R
-    ? R extends "string"
-      ? string
-      : R extends "number"
-      ? number
-      : R extends "boolean"
-      ? boolean
-      : R extends ReadonlyArray<infer E>
-      ? E
-      : R extends "map"
-      ? "properties" extends keyof A
-        ? {
-            [P in keyof A["properties"]]: A["properties"][P] extends infer M
-              ? M extends Attribute
-                ? ItemAttribute<M>
-                : never
-              : never;
-          }
-        : never
-      : R extends "list"
-      ? "items" extends keyof A
-        ? A["items"] extends infer I
-          ? I extends Attribute
-            ? Array<ItemAttribute<I>>
+  A["type"] extends infer T
+    ? T extends OpaquePrimitiveTypeName<infer OP>
+      ? OP
+      : T extends CustomAttributeTypeName<infer CA>
+      ? CA
+      : T extends infer R
+      ? R extends "string"
+        ? string
+        : R extends "number"
+        ? number
+        : R extends "boolean"
+        ? boolean
+        : R extends ReadonlyArray<infer E>
+        ? E
+        : R extends "map"
+        ? "properties" extends keyof A
+          ? {
+              [P in keyof A["properties"]]: A["properties"][P] extends infer M
+                ? M extends Attribute
+                  ? ItemAttribute<M>
+                  : never
+                : never;
+            }
+          : never
+        : R extends "list"
+        ? "items" extends keyof A
+          ? A["items"] extends infer I
+            ? I extends Attribute
+              ? Array<ItemAttribute<I>>
+              : never
             : never
           : never
-        : never
-      : R extends "set"
-      ? "items" extends keyof A
-        ? A["items"] extends infer I
-          ? I extends "string"
-            ? string[]
-            : I extends "number"
-            ? number[]
-            : I extends ReadonlyArray<infer ENUM>
-            ? ENUM[]
+        : R extends "set"
+        ? "items" extends keyof A
+          ? A["items"] extends infer I
+            ? I extends "string"
+              ? string[]
+              : I extends "number"
+              ? number[]
+              : I extends ReadonlyArray<infer ENUM>
+              ? ENUM[]
+              : never
             : never
           : never
+        : R extends "any"
+        ? any
         : never
-      : R extends "any"
-      ? any
       : never
     : never;
 

--- a/test/entity.test-d.ts
+++ b/test/entity.test-d.ts
@@ -1,4 +1,4 @@
-import { Entity, Resolve } from "../";
+import { Entity, Resolve, CustomAttributeType, EntityRecord } from "../";
 import { expectType } from "tsd";
 
 const troubleshoot = <Params extends any[], Response>(
@@ -151,6 +151,42 @@ const requiredMapAttributeEntity = new Entity({
   },
 });
 
+type UnionType =
+  | { prop1: string }
+  | { prop1: string; prop2: number }
+  | { prop3: string }
+  | { prop4: number; prop3: string };
+
+const customAttributeEntity = new Entity({
+  model: {
+    entity: "user",
+    service: "versioncontrol",
+    version: "1",
+  },
+  attributes: {
+    union: {
+      required: true,
+      type: CustomAttributeType<UnionType>("any"),
+    },
+    stringVal: {
+      type: "string",
+    },
+  },
+  indexes: {
+    user: {
+      collection: "overview",
+      pk: {
+        composite: ["stringVal"],
+        field: "pk",
+      },
+      sk: {
+        composite: ["stringVal2"],
+        field: "sk",
+      },
+    },
+  },
+});
+
 entityWithSK
   .update({
     attr1: "abc",
@@ -200,3 +236,8 @@ expectType<{
     test?: string;
   };
 }>(magnify(item));
+
+type CustomAttributeEntityType = EntityRecord<typeof customAttributeEntity>;
+const unionItem = {} as CustomAttributeEntityType["union"];
+
+expectType<UnionType>(magnify(unionItem));


### PR DESCRIPTION
**Issue**

```tsx
const key = 'key';

type CustomAttributeTypeName<T> = { [key]: T };

// this is a simplified version of what EntityRecord will return for
// the union type
type T1 =
  | CustomAttributeTypeName<{ prop1: string; prop2: string; }>
  | CustomAttributeTypeName<{ prop1: string }>
  | CustomAttributeTypeName<{ prop3: string }>;


// This doesn't work. `{ deploymentId: string; projectId: string; }` is missing from union.
// subtypes for a union items seem to get collapsed.
type T2 = T1 extends CustomAttributeTypeName<infer T> ? T : never;
// This works. underlying union types perserved.
type T3 = T1 extends infer U ? U extends CustomAttributeTypeName<infer U> ? U : never : never;
```

without the outer unboxing of the union type (the outer `infer`), TS collapses some of the underlying union types.

[TS playground example](https://www.typescriptlang.org/play?ts=5.3.2&ssl=18&ssc=1&pln=2&pc=1#code/MYewdgzgLgBA1gUwJ4wLwwOSKRg3AKHyiQAcEYBhAV2hAFsBBKKAJwEsAjKqBAFVIQA5AIZ0EAHl4A+NDADeMANrYAugC4YvGAF8C+APT6YUABZsIMczGEwIbOiQA2bAGZsEAExgA3BCzvgMCAuMADuJsKwAKJgUGzEAEoIoCxeoWyOjjAsCFBULGAwLiAsBkam5FRgbIHEZEQCmgCMaPgwMAA+lDRQ9EysnNx8AiJi4gokLCAkTRrQ7GAA5rgwk9MATHMDSyvaUm2d3bSMzOxcPPxkoxITUzNbC4s6++1d1Mf9Z0OXQqI3q3cAMwPNhLZ56MqaMwWDwgBAQMAYWChEpwAB0MAABgoPAgnCAkGJYgBJDwgnYAkAAK2SUFJ5OWOkxlgsdHMdjBLimdBgVRqYDRkIgVA4dXhRRK1l51UC8QQdAsEAQ8uMIBgi1yMFAmWEJCVHkFYs061kvBaCAAHjwwB4LO9eicBudhlc-uJQS4-JoZAB+TQwDRgBC+FgEQxQqwolhwCAYqq4liOJCgp582oCCxkfx+XwGhpkTSA03mq0IG0WD1egCqMD9Nct1ttRwdn0GFxGbsrLBgVd9PYDMCDIYHQ78BCAA)


**Before**
`T2` returns
```tsx
{prop1: string;} | {prop3: string;}
```

**After**
`T3` returns
```tsx
{prop1: string;} | {prop1: string; prop2: string;} | {prop3: string;}
```