### PR TITLE
Corrects upsert typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -398,7 +398,7 @@ All notable changes to this project will be documented in this file. Breaking ch
 ## [2.7.0] - 2023-07-01
 
 ### Fixed
-- Fixes return typing for `delete`, `remove`, `update` and `upsert` operations. These types were incorrect and did not reflect the real values returned. Instead of breaking the APIs, changing response types to `T | null`, the new response type is now the Entity's key composite values by default. You can also now use the Execution Option `response` to get back the item as it exists in the table. This is the closed I could get to a non-breaking change that also fixes the incorrect return typing for these methods.
+- Fixes return typing for `delete`, `remove`, `update` and `upsert` operations. These types were incorrect and did not reflect the real values returned. Instead of breaking the APIs, changing response types to `T | null`, the new response type is now the Entity's key composite values by default. You can also now use the Execution Option `response` to get back the item as it exists in the table. This is the closest I could get to a non-breaking change that also fixes the incorrect return typing for these methods.
 - Fixes typing for `contains` where conditions to accept collection element values (e.g., `set` and `list` type attributes).
 - The exported type `UpdateEntityItem` was incorrectly typed, it now includes the correct typing as the values that can be passed to the `set` method
 
@@ -513,6 +513,10 @@ All notable changes to this project will be documented in this file. Breaking ch
 ### Added
 - Adds new query execution option `count` which allows you to specify a specific item count to return from a query. This is useful for cases where you must return a specific/consistent number of items from a query, a deceptively difficult task with DynamoDB and Single Table Design.
 
-## [2.13.1] - 2023-01-23
+## [2.13.1] - 2024-01-23
 ### Fixed
-- Fixes custom attribute type extraction for union types with RecordItem. Patch provided by GitHub user @wentsul via [PR #346](https://github.com/tywalch/electrodb/pull/346). Thank you for another great addition! 
+- Fixes custom attribute type extraction for union types with RecordItem. Patch provided by GitHub user @wentsul via [PR #346](https://github.com/tywalch/electrodb/pull/346). Thank you for another great addition!
+
+## [2.13.2] - 2024-02-15
+### Fixed
+- Addresses [Discussion #349](https://github.com/tywalch/electrodb/discussions/349), upsert should return the same type as Put and Create. This must have been an oversight in `2.7.0` when the response type was changed. This is considered non-breaking as the response type was a partial of the same type being returned now. Thank you, @eXamadeus for bringing forward this discussion!  

--- a/index.d.ts
+++ b/index.d.ts
@@ -2884,19 +2884,7 @@ export type UpsertRecordGo<ResponseType, Keys> = <
   Options extends UpdateQueryOptions = UpdateQueryOptions,
 >(
   options?: Options,
-) => Options extends infer O
-  ? "response" extends keyof O
-    ? O["response"] extends "all_new"
-      ? Promise<{ data: T }>
-      : O["response"] extends "all_old"
-      ? Promise<{ data: T }>
-      : O["response"] extends "default"
-      ? Promise<{ data: Keys }>
-      : O["response"] extends "none"
-      ? Promise<{ data: null }>
-      : Promise<{ data: Partial<T> }>
-    : Promise<{ data: Keys }>
-  : never;
+) => Promise<{ data: T }>;
 
 export type PutRecordGo<ResponseType> = <
   T = ResponseType,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1504,6 +1504,20 @@ expectAssignable<"paramtest">(
   entityWithoutSK.create(putItemFull).params<"paramtest">(),
 );
 
+// upsert (responses)
+expectAssignable<Promise<ItemWithoutSK>>(
+    entityWithoutSK.upsert(putItemFull)
+        .go()
+        .then((res) => res.data),
+)
+
+expectAssignable<Promise<Item>>(
+    entityWithSK
+        .upsert(putItemFull)
+        .go()
+        .then((res) => res.data),
+);
+
 // Update
 let setItemFull = {
   attr4: "abc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrodb",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "description": "A library to more easily create and interact with multiple entities and heretical relationships in dynamodb",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Upsert should return the same type as Put and Create. This must have been an oversight in `2.7.0` when the response type was changed. This is considered non-breaking as the response type was a partial of the same type being returned now. Thank you, @eXamadeus for bringing forward this discussion!