### PR TITLE
fix typo in batch-put.mdx

### DIFF
--- a/www/src/pages/en/mutations/batch-put.mdx
+++ b/www/src/pages/en/mutations/batch-put.mdx
@@ -54,7 +54,7 @@ const unprocessed = await StoreLocations.put([
     leaseEndDate: "2021-01-22",
     rent: "1500.00",
   },
-]).go({ concurrent: 1 }); // `concurrent` value is optional and default's to `1`
+]).go({ concurrency: 1 }); // `concurrency` value is optional and default's to `1`
 ```
 
 ## Response Format


### PR DESCRIPTION
The execution option to the `go` method to concurrently perform a mutation is `concurrency` and not `concurrent`.