### PR TITLE
Simple documentation correction for "create" mutation

### DIFF
--- a/www/src/pages/en/mutations/create.mdx
+++ b/www/src/pages/en/mutations/create.mdx
@@ -16,7 +16,7 @@ import ExampleSetup from "../../../partials/entity-query-example-setup.mdx";
 
 <ExampleSetup />
 
-In DynamoDB, `put` operations by default will overwrite a record if record being updated does not exist. In **_ElectroDB_**, the `create` method will utilize the `attribute_not_exists()` parameter to ensure records are only "created" and not overwritten when inserting new records into the table.
+In DynamoDB, `put` operations by default will create a record if the record being updated does not exist. In **_ElectroDB_**, the `create` method will utilize the `attribute_not_exists()` parameter to ensure records are only "created" and not overwritten when inserting new records into the table.
 
 The `create()` operation will trigger the `default`, and `set` attribute callbacks when writing to DynamoDB. By default, after writing to DynamoDB, ElectroDB will format and return the record through the same process as a Get/Query, which will invoke the `get` callback on all included attributes. If this behaviour is not desired, use the [Execution Option](#execution-options) `response:"none"` to return a null value.
 


### PR DESCRIPTION
Was reading some documentation and noticed a sentence that wasn't quite worded correctly. I think this clears it up!