### PR TITLE
Fix incorrectly documented QueryResponse type in typescript.mdx

### DIFF
--- a/www/src/pages/en/reference/typescript.mdx
+++ b/www/src/pages/en/reference/typescript.mdx
@@ -51,7 +51,7 @@ The `QueryResponse` type is the same type returned by an ElectroDB Query.
 
 ```typescript
 export type QueryResponse<E extends Entity<any, any, any, any>> = {
-  data: EntityItem<E>;
+  data: EntityItem<E>[];
   cursor: string | null;
 };
 ```


### PR DESCRIPTION
As per the index.d.ts file and in general how query responses are shaped the `QueryResponse` type is correctly typed as:
```
export type QueryResponse<E extends Entity<any, any, any, any>> = {
  data: EntityItem<E>[];
  cursor: string | null;
};
```
though in the docs reference it was typed as:
```
export type QueryResponse<E extends Entity<any, any, any, any>> = {
  data: EntityItem<E>;
  cursor: string | null;
};
```
Notice the `data: EntityItem<E>[]` in the declaration file vs `data: EntityItem<E>` in the docs.
This kinda confused me and hence this docs correction.