### PR TITLE
fix: use unmarshall rather than unmarshallOutput; private api

### DIFF
--- a/buildbrowser.sh
+++ b/buildbrowser.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 original_line_lib="const lib = require\('@aws-sdk\/lib-dynamodb'\)"
 safe_line_lib="const lib = {}"
-original_line_unmarshall_output="const util = require\('@aws-sdk\/lib-dynamodb\/dist-cjs\/commands\/utils'\)"
+original_line_unmarshall_output="const util = require\('./unmarshallOutput'\)"
 safe_line_unmarshall_output="const util = {}"
 filePath="./src/client.js"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electrodb",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "electrodb",
-      "version": "2.14.1",
+      "version": "2.14.2",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/lib-dynamodb": "^3.395.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "directory": "test"
   },
   "dependencies": {
-    "@aws-sdk/lib-dynamodb": "3.395.0",
+    "@aws-sdk/lib-dynamodb": "^3.395.0",
     "jsonschema": "1.2.7"
   }
 }

--- a/src/client.js
+++ b/src/client.js
@@ -1,5 +1,5 @@
-const lib = require('@aws-sdk/lib-dynamodb')
-const util = require('@aws-sdk/lib-dynamodb/dist-cjs/commands/utils')
+const lib = require("@aws-sdk/lib-dynamodb");
+const util = require("./unmarshallOutput");
 const { isFunction } = require("./validations");
 const { ElectroError, ErrorCodes } = require("./errors");
 const DocumentClientVersions = {
@@ -7,6 +7,7 @@ const DocumentClientVersions = {
   v3: "v3",
   electro: "electro",
 };
+
 const unmarshallOutput = util.unmarshallOutput || ((val) => val);
 
 const v3Methods = ["send"];
@@ -287,7 +288,6 @@ function normalizeConfig(config = {}) {
 }
 
 module.exports = {
-  util,
   v2Methods,
   v3Methods,
   normalizeClient,

--- a/src/unmarshallOutput.js
+++ b/src/unmarshallOutput.js
@@ -1,0 +1,39 @@
+const util_dynamodb_1 = require("@aws-sdk/util-dynamodb");
+const processObj = (obj, processFunc, children) => {
+  if (obj !== undefined) {
+    if (!children || (Array.isArray(children) && children.length === 0)) {
+      return processFunc(obj);
+    } else {
+      if (Array.isArray(children)) {
+        return processKeysInObj(obj, processFunc, children);
+      } else {
+        return processAllKeysInObj(obj, processFunc, children.children);
+      }
+    }
+  }
+  return undefined;
+};
+const processKeyInObj = (obj, processFunc, children) => {
+  if (Array.isArray(obj)) {
+    return obj.map((item) => processObj(item, processFunc, children));
+  }
+  return processObj(obj, processFunc, children);
+};
+const processKeysInObj = (obj, processFunc, keyNodes) => {
+  const accumulator = { ...obj };
+  return keyNodes.reduce((acc, { key, children }) => {
+    acc[key] = processKeyInObj(acc[key], processFunc, children);
+    return acc;
+  }, accumulator);
+};
+const processAllKeysInObj = (obj, processFunc, children) =>
+  Object.entries(obj).reduce((acc, [key, value]) => {
+    acc[key] = processKeyInObj(value, processFunc, children);
+    return acc;
+  }, {});
+const unmarshallOutput = (obj, keyNodes, options) => {
+  const unmarshallFunc = (toMarshall) =>
+    (0, util_dynamodb_1.unmarshall)(toMarshall, options);
+  return processKeysInObj(obj, unmarshallFunc, keyNodes);
+};
+exports.unmarshallOutput = unmarshallOutput;


### PR DESCRIPTION
Use `unmarshall` rather than the internal api `unmarshallOutput`

According to https://github.com/aws/aws-sdk-js-v3/issues/6276 this is the correct fix, however unmarshallOutput calls unmarshall and then does some additional processing so I am not convinced.

Currently 2 tests fail and I suspect that this is due to the additional processing being performed