### PR TITLE
data of entity.delete().go() should be nullable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2912,16 +2912,14 @@ export type DeleteRecordOperationGo<ResponseType, Keys> = <
   options?: Options,
 ) => Options extends infer O
   ? "response" extends keyof O
-    ? O["response"] extends "all_new"
-      ? Promise<{ data: T }>
-      : O["response"] extends "all_old"
-      ? Promise<{ data: T }>
+    ? O["response"] extends "all_old"
+      ? Promise<{ data: T | null }>
       : O["response"] extends "default"
-      ? Promise<{ data: Keys }>
+      ? Promise<{ data: Keys | null }>
       : O["response"] extends "none"
       ? Promise<{ data: null }>
-      : Promise<{ data: Partial<T> }>
-    : Promise<{ data: Keys }>
+      : Promise<{ data: Keys | null }>
+    : Promise<{ data: Keys | null }>
   : never;
 
 export type BatchWriteGo<ResponseType> = <O extends BulkOptions>(


### PR DESCRIPTION
Delete method doesn't have ConditionExpression that the item being deleted exists by default.

* fix: change the data type from `Partial<T>` to `Keys | null` when `response` option is absent or undefined
* fix: make the data types nullable in all cases
* refactor: remove `O["response"] extends "all_new"` case because `O extends DeleteQueryOptions` and `DeleteQueryOptions['response']?: "default" | "none" | "all_old"` does not include `"all_new"`