### PR TITLE
Add option to pass ignoreOwnership during entity creation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4994,6 +4994,7 @@ export type EntityConfiguration = {
     entity?: string;
     version?: string;
   };
+  ignoreOwnership?: boolean;
 };
 
 export class Entity<

--- a/src/entity.js
+++ b/src/entity.js
@@ -1632,7 +1632,7 @@ class Entity {
       consistent: undefined,
       compare: ComparisonTypes.keys,
       complete: false,
-      ignoreOwnership: false,
+      ignoreOwnership: !!this.config.ignoreOwnership,
       _providedIgnoreOwnership: false,
       _isPagination: false,
       _isCollectionQuery: false,


### PR DESCRIPTION
We are migrating our codebase to use electrodb. Devs sometimes forget to include this flag and it fails silently because types are not narrowed down from the flags passed inside the .go({...}). It will be convenient if there was an option to pass in ignoreOwnership when creating entities so that errors are minimized. Example: 

`const entity = new Entity(..., {table: ..., ignoreOwnership: true})`

so that it is applied to all `.go({// no need to pass ignoreOwnership explicitly here for all queries})`

Default will always be false so there will be no issues unless explicitly added in the entity. 