### PR TITLE
fix formatting unique expression attribute names

### DIFF
--- a/src/operations.js
+++ b/src/operations.js
@@ -48,8 +48,7 @@ class ExpressionState {
       this.formattedNameToOriginalNameMap.has(formattedName) &&
       this.formattedNameToOriginalNameMap.get(formattedName) !== originalName
     ) {
-      nameSuffix++;
-      formattedName = `${originalFormattedName}_${nameSuffix}`;
+      formattedName = `${originalFormattedName}_${++nameSuffix}`;
     }
 
     this.formattedNameToOriginalNameMap.set(formattedName, originalName);

--- a/src/operations.js
+++ b/src/operations.js
@@ -41,20 +41,15 @@ class ExpressionState {
       formattedName = `p${formattedName}`;
     }
 
-    // Check if we've seen this stripped name before
-    if (this.formattedNameToOriginalNameMap.has(formattedName)) {
-      const existing = this.formattedNameToOriginalNameMap.get(formattedName);
-      if (existing !== originalName) {
-        // If we have a collision (e.g., "user-name" and "username" both become "username"),
-        // append a numeric suffix (username_2, username_3, etc.)
-        let suffix = 2;
-        while (
-          this.formattedNameToOriginalNameMap.has(`${formattedName}_${suffix}`)
-        ) {
-          suffix++;
-        }
-        formattedName = `${formattedName}_${suffix}`;
-      }
+    let nameSuffix = 1;
+    let originalFormattedName = formattedName;
+
+    while (
+      this.formattedNameToOriginalNameMap.has(formattedName) &&
+      this.formattedNameToOriginalNameMap.get(formattedName) !== originalName
+    ) {
+      nameSuffix++;
+      formattedName = `${originalFormattedName}_${nameSuffix}`;
     }
 
     this.formattedNameToOriginalNameMap.set(formattedName, originalName);

--- a/src/operations.js
+++ b/src/operations.js
@@ -41,8 +41,8 @@ class ExpressionState {
       formattedName = `p${formattedName}`;
     }
 
+    const originalFormattedName = formattedName;
     let nameSuffix = 1;
-    let originalFormattedName = formattedName;
 
     while (
       this.formattedNameToOriginalNameMap.has(formattedName) &&

--- a/test/connected.update.spec.js
+++ b/test/connected.update.spec.js
@@ -1384,6 +1384,7 @@ describe("Update Item", () => {
       .delete({ tags: updates.tags })
       .data((attr, op) => {
         op.set(attr.custom.prop1, updates.prop1);
+        op.set(attr.custom["prop1 "], updates.prop1);
         op.add(attr.views, created.custom.prop3);
         op.set(attr.license, op.name(attr.files[0]));
         op.add(attr.recentCommits[0].views, updates.recentCommitsViews);
@@ -1393,7 +1394,7 @@ describe("Update Item", () => {
 
     expect(params).to.deep.equal({
       UpdateExpression:
-        "SET #stars = (if_not_exists(#stars, :stars_default_value_u0) - :stars_u0), #files = list_append(if_not_exists(#files, :files_default_value_u0), :files_u0), #description = :description_u0, #custom.#prop1 = :custom_u0, #license = #files[0], #repoOwner = :repoOwner_u0, #repoName = :repoName_u0, #__edb_e__ = :__edb_e___u0, #__edb_v__ = :__edb_v___u0 REMOVE #about, #recentCommits[1].#message ADD #followers :followers_u0, #views :views_u0, #recentCommits[0].#views :views_u1 DELETE #tags :tags_u0",
+        "SET #stars = (if_not_exists(#stars, :stars_default_value_u0) - :stars_u0), #files = list_append(if_not_exists(#files, :files_default_value_u0), :files_u0), #description = :description_u0, #custom.#prop1 = :custom_u0, #custom.#prop1_2 = :custom_u1, #license = #files[0], #repoOwner = :repoOwner_u0, #repoName = :repoName_u0, #__edb_e__ = :__edb_e___u0, #__edb_v__ = :__edb_v___u0 REMOVE #about, #recentCommits[1].#message ADD #followers :followers_u0, #views :views_u0, #recentCommits[0].#views :views_u1 DELETE #tags :tags_u0",
       ExpressionAttributeNames: {
         "#followers": "followers",
         "#stars": "stars",
@@ -1403,6 +1404,7 @@ describe("Update Item", () => {
         "#tags": "tags",
         "#custom": "custom",
         "#prop1": "prop1",
+        "#prop1_2": "prop1 ",
         "#views": "views",
         "#recentCommits": "recentCommits",
         "#message": "message",
@@ -1421,6 +1423,7 @@ describe("Update Item", () => {
         ":description_u0": "updated description",
         ":tags_u0": params.ExpressionAttributeValues[":tags_u0"],
         ":custom_u0": "def",
+        ":custom_u1": "def",
         ":views_u0": 200,
         ":views_u1": 3,
         ":repoName_u0": repoName,
@@ -1704,7 +1707,7 @@ describe("Update Item", () => {
 
       const itemBefore = await users
         .get({ username })
-        .go({ data: 'raw' })
+        .go({ data: "raw" })
         .then((res) => res.data);
 
       expect(itemBefore).to.deep.equal({
@@ -1757,7 +1760,7 @@ describe("Update Item", () => {
 
       const itemAfter = await users
         .get({ username })
-        .go({ data: 'raw' })
+        .go({ data: "raw" })
         .then((res) => res.data);
 
       expect(itemAfter).to.deep.equal({
@@ -1851,7 +1854,7 @@ describe("Update Item", () => {
 
       const itemBefore = await users
         .get({ username })
-        .go({ data: 'raw' })
+        .go({ data: "raw" })
         .then((res) => res.data);
 
       expect(itemBefore).to.deep.equal({
@@ -1903,7 +1906,7 @@ describe("Update Item", () => {
 
       const itemAfter = await users
         .get({ username })
-        .go({ data: 'raw' })
+        .go({ data: "raw" })
         .then((res) => res.data);
 
       expect(itemAfter).to.deep.equal({
@@ -1998,7 +2001,7 @@ describe("Update Item", () => {
 
       const itemBefore = await users
         .get({ username })
-        .go({ data: 'raw' })
+        .go({ data: "raw" })
         .then((res) => res.data);
 
       expect(itemBefore).to.deep.equal({

--- a/test/connected.update.spec.js
+++ b/test/connected.update.spec.js
@@ -1385,6 +1385,7 @@ describe("Update Item", () => {
       .data((attr, op) => {
         op.set(attr.custom.prop1, updates.prop1);
         op.set(attr.custom["prop1 "], updates.prop1);
+        op.set(attr.custom["prop1  "], updates.prop1);
         op.add(attr.views, created.custom.prop3);
         op.set(attr.license, op.name(attr.files[0]));
         op.add(attr.recentCommits[0].views, updates.recentCommitsViews);
@@ -1394,7 +1395,7 @@ describe("Update Item", () => {
 
     expect(params).to.deep.equal({
       UpdateExpression:
-        "SET #stars = (if_not_exists(#stars, :stars_default_value_u0) - :stars_u0), #files = list_append(if_not_exists(#files, :files_default_value_u0), :files_u0), #description = :description_u0, #custom.#prop1 = :custom_u0, #custom.#prop1_2 = :custom_u1, #license = #files[0], #repoOwner = :repoOwner_u0, #repoName = :repoName_u0, #__edb_e__ = :__edb_e___u0, #__edb_v__ = :__edb_v___u0 REMOVE #about, #recentCommits[1].#message ADD #followers :followers_u0, #views :views_u0, #recentCommits[0].#views :views_u1 DELETE #tags :tags_u0",
+        "SET #stars = (if_not_exists(#stars, :stars_default_value_u0) - :stars_u0), #files = list_append(if_not_exists(#files, :files_default_value_u0), :files_u0), #description = :description_u0, #custom.#prop1 = :custom_u0, #custom.#prop1_2 = :custom_u1, #custom.#prop1_3 = :custom_u2, #license = #files[0], #repoOwner = :repoOwner_u0, #repoName = :repoName_u0, #__edb_e__ = :__edb_e___u0, #__edb_v__ = :__edb_v___u0 REMOVE #about, #recentCommits[1].#message ADD #followers :followers_u0, #views :views_u0, #recentCommits[0].#views :views_u1 DELETE #tags :tags_u0",
       ExpressionAttributeNames: {
         "#followers": "followers",
         "#stars": "stars",
@@ -1405,6 +1406,7 @@ describe("Update Item", () => {
         "#custom": "custom",
         "#prop1": "prop1",
         "#prop1_2": "prop1 ",
+        "#prop1_3": "prop1  ",
         "#views": "views",
         "#recentCommits": "recentCommits",
         "#message": "message",
@@ -1424,6 +1426,7 @@ describe("Update Item", () => {
         ":tags_u0": params.ExpressionAttributeValues[":tags_u0"],
         ":custom_u0": "def",
         ":custom_u1": "def",
+        ":custom_u2": "def",
         ":views_u0": 200,
         ":views_u1": 3,
         ":repoName_u0": repoName,

--- a/test/connected.update.spec.js
+++ b/test/connected.update.spec.js
@@ -1707,7 +1707,7 @@ describe("Update Item", () => {
 
       const itemBefore = await users
         .get({ username })
-        .go({ data: "raw" })
+        .go({ data: 'raw' })
         .then((res) => res.data);
 
       expect(itemBefore).to.deep.equal({
@@ -1760,7 +1760,7 @@ describe("Update Item", () => {
 
       const itemAfter = await users
         .get({ username })
-        .go({ data: "raw" })
+        .go({ data: 'raw' })
         .then((res) => res.data);
 
       expect(itemAfter).to.deep.equal({
@@ -1854,7 +1854,7 @@ describe("Update Item", () => {
 
       const itemBefore = await users
         .get({ username })
-        .go({ data: "raw" })
+        .go({ data: 'raw' })
         .then((res) => res.data);
 
       expect(itemBefore).to.deep.equal({
@@ -1906,7 +1906,7 @@ describe("Update Item", () => {
 
       const itemAfter = await users
         .get({ username })
-        .go({ data: "raw" })
+        .go({ data: 'raw' })
         .then((res) => res.data);
 
       expect(itemAfter).to.deep.equal({
@@ -2001,7 +2001,7 @@ describe("Update Item", () => {
 
       const itemBefore = await users
         .get({ username })
-        .go({ data: "raw" })
+        .go({ data: 'raw' })
         .then((res) => res.data);
 
       expect(itemBefore).to.deep.equal({


### PR DESCRIPTION
closes https://github.com/tywalch/electrodb/issues/460

Previous behavior:

When updating an item with a map attribute, if you attempt to set multiple keys that are identical after removing non-word characters (\w), Electro will generate the same expression attribute name for both keys. This occurs even though the original keys are different, leading to conflicts in the update operation.

This PR introduces a new change that ensures that each key will generate a unique expression attribute name.

Previously the following operation

```
tasks.patch({ id: '1' }).data((attrs, ops) => {
  ops.set(attrs.map['hello world'], 1)
  ops.set(attrs.map['hello    world'], 1)
}).go()
```

would generate only 1 expression attribute name `#helloworld`. this also throws an error in dynamo because you are not allowed to update the same field multiple times in the same operation.

The new PR would create 2 expression attribute names: `#helloworld` and `#helloworld_2`.

I added tests for this as well.