### PR TITLE
fix(#439): add missing TypeScript types for `attributes` property on scan/find/match methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -584,3 +584,7 @@ All notable changes to this project will be documented in this file. Breaking ch
 ## [3.4.2]
 ### Fixed
 - [Issue #483](https://github.com/tywalch/electrodb/issues/483): This fix addresses the problem where ElectroDB returned an empty object when the get method was called for a non-existent item and the `attributes` parameter was specified. It now correctly returns `null` as expected.
+
+## [3.4.3]
+### Fixed
+- [Issue #439](https://github.com/tywalch/electrodb/issues/439); Fixed missing TypeScript types for `attributes` property on `scan`, `find`, and `match` methods.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1236,10 +1236,10 @@ export interface RecordsActionOptions<
   F extends string,
   C extends string,
   S extends Schema<A, F, C>,
-  Items,
+  ResponseItem,
   IndexCompositeAttributes,
 > {
-  go: QueryRecordsGo<Items>;
+  go: QueryRecordsGo<ResponseItem>;
   params: ParamRecord;
   where: WhereClause<
     A,
@@ -1247,7 +1247,7 @@ export interface RecordsActionOptions<
     C,
     S,
     Item<A, F, C, S, S["attributes"]>,
-    RecordsActionOptions<A, F, C, S, Items, IndexCompositeAttributes>
+    RecordsActionOptions<A, F, C, S, ResponseItem, IndexCompositeAttributes>
   >;
 }
 
@@ -2854,11 +2854,16 @@ export type ServiceQueryRecordsGo<
   options?: Options,
 ) => Promise<{ data: T; cursor: string | null }>;
 
-export type QueryRecordsGo<ResponseType, Options = QueryOptions> = <
-  T = ResponseType,
->(
+export type QueryRecordsGo<Item> = <Options extends GoQueryTerminalOptions<keyof Item>>(
   options?: Options,
-) => Promise<{ data: T; cursor: string | null }>;
+) => Options extends GoQueryTerminalOptions<infer Attr>
+  ? Promise<{
+      data: Array<{
+        [Name in keyof Item as Name extends Attr ? Name : never]: Item[Name];
+      }>;
+      cursor: string | null;
+    }>
+  : Promise<{ data: Array<Item>; cursor: string | null }>;
 
 export type UpdateRecordGo<ResponseType, Keys> = <
   T = ResponseType,
@@ -5254,7 +5259,7 @@ export class Entity<
     F,
     C,
     S,
-    ResponseItem<A, F, C, S>[],
+    ResponseItem<A, F, C, S>,
     AllTableIndexCompositeAttributes<A, F, C, S>
   >;
 
@@ -5265,7 +5270,7 @@ export class Entity<
     F,
     C,
     S,
-    ResponseItem<A, F, C, S>[],
+    ResponseItem<A, F, C, S>,
     AllTableIndexCompositeAttributes<A, F, C, S>
   >;
 
@@ -5274,7 +5279,7 @@ export class Entity<
     F,
     C,
     S,
-    ResponseItem<A, F, C, S>[],
+    ResponseItem<A, F, C, S>,
     TableIndexCompositeAttributes<A, F, C, S>
   >;
   query: Queries<A, F, C, S>;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -650,6 +650,23 @@ expectAssignable<"paramtest">(
 expectAssignable<"paramtest">(
   entityWithoutSK.get({ attr1: "abc" }).params<"paramtest">(),
 );
+expectAssignable<Promise<{ attr1: string; attr2: string }[]>>(
+  entityWithSK.scan
+    .go({ attributes: ["attr1", "attr2"] })
+    .then((res) => res.data),
+);
+expectAssignable<Promise<{ attr1: string; attr7?: any; attr6?: number }[]>>(
+  entityWithSK
+    .find({ attr10: true })
+    .go({ attributes: ["attr1", "attr7", "attr6"] })
+    .then((res) => res.data),
+);
+expectAssignable<Promise<{ attr4: "abc" | "ghi"; attr5?: string }[]>>(
+  entityWithSK
+    .match({ attr3: "def" })
+    .go({ attributes: ["attr4", "attr5"] })
+    .then((res) => res.data),
+);
 entityWithSK
   .get([{ attr1: "abc", attr2: "def" }])
   .go()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electrodb",
-  "version": "3.0.0",
+  "version": "3.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "electrodb",
-      "version": "3.0.0",
+      "version": "3.4.3",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/lib-dynamodb": "^3.654.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrodb",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "A library to more easily create and interact with multiple entities and heretical relationships in dynamodb",
   "main": "index.js",
   "scripts": {

--- a/test/queries.test-d.ts
+++ b/test/queries.test-d.ts
@@ -6,6 +6,7 @@ import {
   GoQueryTerminal,
   // PageQueryTerminal,
   Queries,
+  QueryRecordsGo,
 } from "../";
 import { expectType, expectError, expectNotType } from "tsd";
 
@@ -46,6 +47,10 @@ class MockEntity<
 
   getGoQueryTerminal(): GoQueryTerminal<A, F, C, S, ResponseItem<A, F, C, S>> {
     return {} as GoQueryTerminal<A, F, C, S, ResponseItem<A, F, C, S>>;
+  }
+
+  getScanTerminal(): QueryRecordsGo<ResponseItem<A, F, C, S>> {
+    return {} as QueryRecordsGo<ResponseItem<A, F, C, S>>;
   }
 
   // getPageQueryTerminal(): PageQueryTerminal<A,F,C,S, ResponseItem<A,F,C,S>, {abc: string}> {
@@ -440,7 +445,23 @@ const entityWithoutSKE = new Entity({
 });
 
 const entityWithSKGo = entityWithSK.getGoQueryTerminal();
+const entityWithSKScan = entityWithSK.getScanTerminal();
+
 entityWithSKGo({
+  attributes: ["attr2", "attr3", "attr4", "attr6", "attr8"],
+}).then((results) => {
+  expectType<
+    {
+      attr2: string;
+      attr3?: "123" | "def" | "ghi" | undefined;
+      attr4: "abc" | "ghi";
+      attr6?: number | undefined;
+      attr8: boolean;
+    }[]
+  >(results.data);
+});
+
+entityWithSKScan({
   attributes: ["attr2", "attr3", "attr4", "attr6", "attr8"],
 }).then((results) => {
   expectType<
@@ -472,7 +493,23 @@ entityWithSKGo({
 // });
 
 const entityWithoutSKGo = entityWithoutSK.getGoQueryTerminal();
+const entityWithoutSKScan = entityWithoutSK.getScanTerminal();
+
 entityWithoutSKGo({
+  attributes: ["attr2", "attr3", "attr4", "attr6", "attr8"],
+}).then((results) => {
+  expectType<
+    {
+      attr2?: string | undefined;
+      attr3?: "123" | "def" | "ghi" | undefined;
+      attr4: "abc" | "def";
+      attr6?: number | undefined;
+      attr8: boolean;
+    }[]
+  >(magnify(results.data));
+});
+
+entityWithoutSKScan({
   attributes: ["attr2", "attr3", "attr4", "attr6", "attr8"],
 }).then((results) => {
   expectType<

--- a/test/ts_connected.crud.spec.ts
+++ b/test/ts_connected.crud.spec.ts
@@ -4363,6 +4363,59 @@ describe("attributes query option", () => {
         attr10: item.attr10,
       },
     ]);
+
+    const scanItem = await entityWithSK.scan
+      .go({
+        attributes: ["attr2", "attr9", "attr5", "attr10"],
+      })
+      .then((res) => res.data);
+
+    expect(scanItem).to.deep.equal([
+      {
+        attr2: item.attr2,
+        attr9: item.attr9,
+        attr5: item.attr5,
+        attr10: item.attr10,
+      },
+    ]);
+
+    const matchItem = await entityWithSK
+      .match({
+        attr1: item.attr1,
+        attr2: item.attr2,
+      })
+      .go({
+        attributes: ["attr2", "attr9", "attr5", "attr10"],
+      })
+      .then((res) => res.data);
+
+    expect(matchItem).to.deep.equal([
+      {
+        attr2: item.attr2,
+        attr9: item.attr9,
+        attr5: item.attr5,
+        attr10: item.attr10,
+      },
+    ]);
+
+    const findItem = await entityWithSK
+      .find({
+        attr1: item.attr1,
+        attr2: item.attr2,
+      })
+      .go({
+        attributes: ["attr2", "attr9", "attr5", "attr10"],
+      })
+      .then((res) => res.data);
+
+    expect(findItem).to.deep.equal([
+      {
+        attr2: item.attr2,
+        attr9: item.attr9,
+        attr5: item.attr5,
+        attr10: item.attr10,
+      },
+    ]);
   });
 
   it("should not add entity identifiers", async () => {


### PR DESCRIPTION
closes #439

added missing TypeScript types for `attributes` when using scan/find/match methods.
also added type tests and integration tests that are all passing