### PR TITLE
HOTFIX 2.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -536,4 +536,8 @@ All notable changes to this project will be documented in this file. Breaking ch
 ## [2.15.0] - 2024-09-19
 ### Updated
 - Updated `@aws-sdk/lib-dynamodb` dependency from pinned version `3.395.0` to latest release `^3.654.0`. This impacts users using the v3 aws-sdk.
-- Adds dependency `@aws-sdk/util-dynamodb` for unmarshalling functionality.
+- Adds dependency `@aws-sdk/util-dynamodb` for unmarshalling functionality. 
+
+## [2.15.1] - 2025-02-11
+### Hotfix
+- Fixed typing for "batchGet" where return type was not defined as a Promise in some cases.

--- a/index.d.ts
+++ b/index.d.ts
@@ -2718,33 +2718,21 @@ type GoBatchGetTerminal<
   ? "preserveBatchOrder" extends keyof Options
     ? Options["preserveBatchOrder"] extends true
       ? Promise<{
-          data: Array<
-            Resolve<
-              | {
-                  [Name in keyof ResponseItem as Name extends Attr
-                    ? Name
-                    : never]: ResponseItem[Name];
-                }
-              | null
-            >
-          >;
-          unprocessed: Array<
-            Resolve<AllTableIndexCompositeAttributes<A, F, C, S>>
-          >;
-        }>
+        data: Array<
+          Resolve<
+            | {
+            [Name in keyof ResponseItem as Name extends Attr
+              ? Name
+              : never]: ResponseItem[Name];
+          }
+            | null
+          >
+        >;
+        unprocessed: Array<
+          Resolve<AllTableIndexCompositeAttributes<A, F, C, S>>
+        >;
+      }>
       : Promise<{
-          data: Array<
-            Resolve<{
-              [Name in keyof ResponseItem as Name extends Attr
-                ? Name
-                : never]: ResponseItem[Name];
-            }>
-          >;
-          unprocessed: Array<
-            Resolve<AllTableIndexCompositeAttributes<A, F, C, S>>
-          >;
-        }>
-    : Promise<{
         data: Array<
           Resolve<{
             [Name in keyof ResponseItem as Name extends Attr
@@ -2756,24 +2744,36 @@ type GoBatchGetTerminal<
           Resolve<AllTableIndexCompositeAttributes<A, F, C, S>>
         >;
       }>
+    : Promise<{
+      data: Array<
+        Resolve<{
+          [Name in keyof ResponseItem as Name extends Attr
+            ? Name
+            : never]: ResponseItem[Name];
+        }>
+      >;
+      unprocessed: Array<
+        Resolve<AllTableIndexCompositeAttributes<A, F, C, S>>
+      >;
+    }>
   : "preserveBatchOrder" extends keyof Options
-  ? Options["preserveBatchOrder"] extends true
-    ? {
+    ? Options["preserveBatchOrder"] extends true
+      ? Promise<{
         data: Array<Resolve<ResponseItem | null>>;
         unprocessed: Array<
           Resolve<AllTableIndexCompositeAttributes<A, F, C, S>>
         >;
-      }
-    : {
+      }>
+      : Promise<{
         data: Array<Resolve<ResponseItem>>;
         unprocessed: Array<
           Resolve<AllTableIndexCompositeAttributes<A, F, C, S>>
         >;
-      }
-  : {
+      }>
+    : Promise<{
       data: Array<Resolve<ResponseItem>>;
       unprocessed: Array<Resolve<AllTableIndexCompositeAttributes<A, F, C, S>>>;
-    };
+    }>;
 
 type GoGetTerminal<
   A extends string,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -905,6 +905,7 @@ expectAssignable<DeleteSingleParamsParams>({
   raw: true,
   table: "abc",
 });
+
 expectAssignable<DeleteSingleParamsParamsWithoutSK>({
   includeKeys: true,
   originalErr: true,
@@ -942,6 +943,7 @@ expectAssignable<DeleteBatchGoParams>({
   concurrency: 10,
   unprocessed: "raw",
 });
+
 expectAssignable<DeleteBatchGoParamsWithoutSK>({
   includeKeys: true,
   originalErr: true,
@@ -961,6 +963,7 @@ expectAssignable<DeleteBatchParamsParams>({
   concurrency: 10,
   unprocessed: "raw",
 });
+
 expectAssignable<DeleteBatchParamsParamsWithoutSK>({
   includeKeys: true,
   originalErr: true,
@@ -987,13 +990,14 @@ entityWithoutSK.delete({ attr1: "asbc" }).where((attr, op) => {
 });
 
 // Results
-expectAssignable<Promise<Item>>(
+expectAssignable<Promise<Item | null>>(
   entityWithSK
     .delete({ attr1: "abc", attr2: "def" })
     .go({ response: "all_old" })
     .then((res) => res.data),
 );
-expectAssignable<Promise<ItemWithoutSK>>(
+
+expectAssignable<Promise<ItemWithoutSK | null>>(
   entityWithoutSK
     .delete({ attr1: "abc" })
     .go({ response: "all_old" })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrodb",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "A library to more easily create and interact with multiple entities and heretical relationships in dynamodb",
   "main": "index.js",
   "scripts": {

--- a/test/entity.test-d.ts
+++ b/test/entity.test-d.ts
@@ -254,3 +254,63 @@ type CustomAttributeEntityItemType = EntityItem<typeof customAttributeEntity>;
 const unionEntityItem = {} as CustomAttributeEntityItemType["union"];
 
 expectType<UnionType>(magnify(unionEntityItem));
+
+const batchGetWithoutAttributesNoPreserve = entityWithSK.get([{attr1: 'abc', attr2: 'def'}]).go();
+expectType<Promise<{
+  data: {
+    attr1: string;
+    attr2: string;
+    attr3?: "def" | "123" | "ghi" | undefined;
+    attr4: "abc" | "ghi";
+    attr5?: string | undefined;
+    attr6?: number | undefined;
+    attr7?: any;
+    attr8: boolean;
+    attr9?: number | undefined;
+    attr10?: boolean | undefined;
+    attr11?: string[] | undefined;
+  }[];
+  unprocessed: {
+    attr1: string;
+    attr2: string;
+  }[];
+}>>(batchGetWithoutAttributesNoPreserve);
+
+const batchGetWithoutAttributesPreserve = entityWithSK.get([{attr1: 'abc', attr2: 'def'}]).go({ preserveBatchOrder: true });
+expectType<Promise<{
+  data: ({
+    attr1: string
+    attr2: string
+    attr3?: "123" | "def" | "ghi" | undefined
+    attr4: "abc" | "ghi"
+    attr5?: string | undefined
+    attr6?: number | undefined
+    attr7?: any
+    attr8: boolean
+    attr9?: number | undefined
+    attr10?: boolean | undefined
+    attr11?: string[] | undefined
+  } | null)[];
+  unprocessed: {
+    attr1: string;
+    attr2: string;
+  }[];
+}>>(batchGetWithoutAttributesPreserve);
+
+const batchGetWithAttributesNoPreserve = entityWithSK.get([{attr1: 'abc', attr2: 'def'}]).go({ attributes: ['attr5', 'attr10'] });
+expectType<Promise<{
+  data: Array<{
+    attr5?: string | undefined;
+    attr10?: boolean | undefined;
+  }>;
+  unprocessed: { attr1: string; attr2: string; }[];
+}>>(magnify(batchGetWithAttributesNoPreserve));
+
+const batchGetWithAttributesPreserve = entityWithSK.get([{attr1: 'abc', attr2: 'def'}]).go({ attributes: ['attr5', 'attr10'], preserveBatchOrder: true });
+expectType<Promise<{
+  data: Array<{
+    attr5?: string | undefined;
+    attr10?: boolean | undefined;
+  } | null>;
+  unprocessed: { attr1: string; attr2: string; }[];
+}>>(magnify(batchGetWithAttributesPreserve));


### PR DESCRIPTION
- Fixed typing for "batchGet" where return type was not defined as a Promise in some cases.