### PR TITLE
fix(#483): return null instead of empty object for non-existent items in get method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -580,3 +580,7 @@ All notable changes to this project will be documented in this file. Breaking ch
 ## [3.4.1]
 ### Fixed
 - [Issue #475](https://github.com/tywalch/electrodb/issues/475); Fixes issue where some users reported errors exporting entities and/or types when using the `CustomAttributeType` function. They would receive an error similar to `Exported variable '...' has or is using name 'OpaquePrimitiveSymbol' from external module "..." but cannot be named.`.  
+
+## [3.4.2]
+### Fixed
+- [Issue #483](https://github.com/tywalch/electrodb/issues/483): This fix addresses the problem where ElectroDB returned an empty object when the get method was called for a non-existent item and the `attributes` parameter was specified. It now correctly returns `null` as expected.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrodb",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "A library to more easily create and interact with multiple entities and heretical relationships in dynamodb",
   "main": "index.js",
   "scripts": {

--- a/src/entity.js
+++ b/src/entity.js
@@ -943,9 +943,6 @@ class Entity {
               response.Item,
               config,
             );
-            if (Object.keys(results).length === 0 && !config._objectOnEmpty) {
-              results = null;
-            }
           } else if (!config._objectOnEmpty) {
             results = null;
           }
@@ -965,9 +962,7 @@ class Entity {
                 item,
                 config,
               );
-              if (Object.keys(record).length > 0 || config._objectOnEmpty) {
-                results.push(record);
-              }
+              results.push(record);
             }
           }
         } else if (response.Attributes) {
@@ -1732,9 +1727,6 @@ class Entity {
 
       if (Array.isArray(option.attributes)) {
         config.attributes = config.attributes.concat(option.attributes);
-        if (config.attributes.length > 0) {
-          config._objectOnEmpty = true;
-        }
       }
 
       if (option.preserveBatchOrder === true) {

--- a/test/connected.crud.spec.js
+++ b/test/connected.crud.spec.js
@@ -5079,8 +5079,6 @@ for (const [clientVersion, client] of [
             prop4: "def",
           };
 
-          let data = null;
-
           let putResult = await entity
             .put(item)
             .go()
@@ -5097,9 +5095,9 @@ for (const [clientVersion, client] of [
             .go()
             .then((res) => res.data);
 
-          expect(putResult).to.deep.equal(data);
-          expect(getResponse).to.deep.equal(data);
-          expect(queryResponse).to.deep.equal([]);
+          expect(putResult).to.deep.equal({});
+          expect(getResponse).to.deep.equal({});
+          expect(queryResponse).to.deep.equal([{}]);
         });
       });
       describe("Numeric and boolean keys", () => {

--- a/test/ts_connected.crud.spec.ts
+++ b/test/ts_connected.crud.spec.ts
@@ -4288,6 +4288,30 @@ describe("attributes query option", () => {
 
       expect(data).to.deep.equal([{}]);
     });
+
+    it('should return null if item does not exist', async () => {
+      const { data } = await User.get({ id: 'does-not-exist' }).go({
+        attributes: ['name'],
+      });
+
+      expect(data).to.deep.equal(null);
+    });
+
+    it('should return an empty array if item does not exist on batch get', async () => {
+      const { data } = await User.get([{ id: 'does-not-exist' }]).go({
+        attributes: ['name'],
+      });
+
+      expect(data).to.deep.equal([]);
+    });
+
+    it('should return an empty array on query for non-existent item', async () => {
+      const { data } = await User.query.byId({ id: 'does-not-exist' }).go({
+        attributes: ['name'],
+      });
+
+      expect(data).to.deep.equal([]);
+    });
   });
 
   it("should return only the attributes specified in query options", async () => {


### PR DESCRIPTION
fixes https://github.com/tywalch/electrodb/issues/483

Previously, ElectroDB would incorrectly return an empty object when the get method was called for a non-existent item and the `attributes` parameter was specified. 

This PR fixes this issue and correctly returns `null`.