### PR TITLE
Add defaultable query options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5007,6 +5007,7 @@ export type EntityConfiguration = {
     entity?: string;
     version?: string;
   };
+  defaultQueryOptions?: QueryOptions;
 };
 
 export class Entity<


### PR DESCRIPTION
- Add a `defaultQueryOptions` property to entity configuration
- Use these defaults when building execution options

The main motivation is so we can do things such as universally ensure that `ignoreOwnership: true` is used for all queries. For example:

```typescript
const entity = new Entity(schema, {
  defaultQueryOptions: { ignoreOwnership: true }
});

// All queries will now use ignoreOwnership: true by default
const result = await entity.get({ id: "123" }).go();
```
