### PR TITLE
feat: index projection & index scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -588,3 +588,8 @@ All notable changes to this project will be documented in this file. Breaking ch
 ## [3.4.3]
 ### Fixed
 - [Issue #439](https://github.com/tywalch/electrodb/issues/439); Fixed missing TypeScript types for `attributes` property on `scan`, `find`, and `match` methods.
+
+## [3.5.0]
+### Added
+- [Issue #507](https://github.com/tywalch/electrodb/issues/507); You can now scan an index. [See docs](https://electrodb.dev/en/queries/scan/#scanning-an-index)
+- [Issue #508](https://github.com/tywalch/electrodb/issues/508); Added support for INCLUDE projection type in index definitions, allowing selective attribute projection for optimized query performance and cost reduction. [See docs](https://electrodb.dev/en/recipes/include-projection-gsi)

--- a/examples/provisionTable/sst.ts
+++ b/examples/provisionTable/sst.ts
@@ -46,14 +46,14 @@ export function ElectroDbTable(
       globalIndexes[secondaryIndex.indexName] = {
         partitionKey: secondaryIndex.partitionKey.field,
         sortKey: secondaryIndex.sortKey?.field,
-        projection: secondaryIndex.keysOnly ? "keys_only" : "all",
+        projection: secondaryIndex.projection,
       };
     } else if (secondaryIndex.type === "LocalSecondaryIndex") {
       fields[secondaryIndex.sortKey.field] = "string";
 
       localIndexes[secondaryIndex.indexName] = {
         sortKey: secondaryIndex.sortKey?.field,
-        projection: secondaryIndex.keysOnly ? "keys_only" : "all",
+        projection: secondaryIndex.projection,
       };
     }
   }

--- a/examples/provisionTable/util.ts
+++ b/examples/provisionTable/util.ts
@@ -49,7 +49,7 @@ export type TableIndexDefinition = {
 export type GlobalSecondaryIndexDefinition = {
   type: "GlobalSecondaryIndex";
   indexName: string;
-  keysOnly: boolean;
+  projection: "all" | "keys_only" | string[];
   partitionKey: IndexKey;
   sortKey?: IndexKey;
 };
@@ -57,7 +57,7 @@ export type GlobalSecondaryIndexDefinition = {
 export type LocalSecondaryIndexDefinition = {
   type: "LocalSecondaryIndex";
   indexName: string;
-  keysOnly: boolean;
+  projection: "all" | "keys_only" | string[];
   sortKey: IndexKey;
 };
 
@@ -105,7 +105,10 @@ export function createSecondaryIndexDefinition(
     indexName: indexDefinition.index!,
     sortKey: toSortKey(indexDefinition.sk),
     partitionKey: toPartitionKey(indexDefinition.pk),
-    keysOnly: indexDefinition.project === "keys_only",
+    projection:
+      typeof indexDefinition.project === "object"
+        ? [...indexDefinition.project, "__edb_e__", "__edb_v__"]
+        : indexDefinition.project ?? "all",
   };
 }
 
@@ -120,7 +123,10 @@ export function createLocalSecondaryIndexDefinition(
     sortKey,
     type: "LocalSecondaryIndex",
     indexName: indexDefinition.index!,
-    keysOnly: indexDefinition.project === "keys_only",
+    projection:
+      typeof indexDefinition.project === "object"
+        ? [...indexDefinition.project, "__edb_e__", "__edb_v__"]
+        : indexDefinition.project ?? "all",
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electrodb",
-  "version": "3.4.3",
+  "version": "3.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "electrodb",
-      "version": "3.4.3",
+      "version": "3.5.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/lib-dynamodb": "^3.654.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrodb",
-  "version": "3.4.3",
+  "version": "3.5.0",
   "description": "A library to more easily create and interact with multiple entities and heretical relationships in dynamodb",
   "main": "index.js",
   "scripts": {

--- a/test/definitions/projection-include-without-edb.json
+++ b/test/definitions/projection-include-without-edb.json
@@ -1,0 +1,75 @@
+{
+  "KeySchema": [
+    {
+      "AttributeName": "pk",
+      "KeyType": "HASH"
+    },
+    {
+      "AttributeName": "sk",
+      "KeyType": "RANGE"
+    }
+  ],
+  "AttributeDefinitions": [
+    {
+      "AttributeName": "pk",
+      "AttributeType": "S"
+    },
+    {
+      "AttributeName": "sk",
+      "AttributeType": "S"
+    },
+    {
+      "AttributeName": "gsi1pk",
+      "AttributeType": "S"
+    },
+    {
+      "AttributeName": "gsi1sk",
+      "AttributeType": "S"
+    },
+    {
+      "AttributeName": "gsi3pk",
+      "AttributeType": "S"
+    },
+    {
+      "AttributeName": "gsi3sk",
+      "AttributeType": "S"
+    }
+  ],
+  "GlobalSecondaryIndexes": [
+    {
+      "IndexName": "gsi1pk-gsi1sk-index",
+      "KeySchema": [
+        {
+          "AttributeName": "gsi1pk",
+          "KeyType": "HASH"
+        },
+        {
+          "AttributeName": "gsi1sk",
+          "KeyType": "RANGE"
+        }
+      ],
+      "Projection": {
+        "ProjectionType": "INCLUDE",
+        "NonKeyAttributes": ["include1", "include2", "include3"]
+      }
+    },
+    {
+      "IndexName": "gsi3pk-gsi3sk-index",
+      "KeySchema": [
+        {
+          "AttributeName": "gsi3pk",
+          "KeyType": "HASH"
+        },
+        {
+          "AttributeName": "gsi3sk",
+          "KeyType": "RANGE"
+        }
+      ],
+      "Projection": {
+        "ProjectionType": "ALL"
+      }
+    }
+  ],
+  "TableName": "projection-include-without-edb",
+  "BillingMode": "PAY_PER_REQUEST"
+}

--- a/test/definitions/projection-include.json
+++ b/test/definitions/projection-include.json
@@ -1,0 +1,100 @@
+{
+  "KeySchema": [
+    {
+      "AttributeName": "pk",
+      "KeyType": "HASH"
+    },
+    {
+      "AttributeName": "sk",
+      "KeyType": "RANGE"
+    }
+  ],
+  "AttributeDefinitions": [
+    {
+      "AttributeName": "pk",
+      "AttributeType": "S"
+    },
+    {
+      "AttributeName": "sk",
+      "AttributeType": "S"
+    },
+    {
+      "AttributeName": "gsi1pk",
+      "AttributeType": "S"
+    },
+    {
+      "AttributeName": "gsi1sk",
+      "AttributeType": "S"
+    },
+    {
+      "AttributeName": "gsi3pk",
+      "AttributeType": "S"
+    },
+    {
+      "AttributeName": "gsi3sk",
+      "AttributeType": "S"
+    },
+    {
+      "AttributeName": "gsi4pk",
+      "AttributeType": "S"
+    },
+    {
+      "AttributeName": "gsi4sk",
+      "AttributeType": "S"
+    }
+  ],
+  "GlobalSecondaryIndexes": [
+    {
+      "IndexName": "gsi1pk-gsi1sk-index",
+      "KeySchema": [
+        {
+          "AttributeName": "gsi1pk",
+          "KeyType": "HASH"
+        },
+        {
+          "AttributeName": "gsi1sk",
+          "KeyType": "RANGE"
+        }
+      ],
+      "Projection": {
+        "ProjectionType": "INCLUDE",
+        "NonKeyAttributes": ["include1", "include2", "include3", "__edb_e__", "__edb_v__"]
+      }
+    },
+    {
+      "IndexName": "gsi3pk-gsi3sk-index",
+      "KeySchema": [
+        {
+          "AttributeName": "gsi3pk",
+          "KeyType": "HASH"
+        },
+        {
+          "AttributeName": "gsi3sk",
+          "KeyType": "RANGE"
+        }
+      ],
+      "Projection": {
+        "ProjectionType": "ALL"
+      }
+    },
+    {
+      "IndexName": "gsi4pk-gsi4sk-index",
+      "KeySchema": [
+        {
+          "AttributeName": "gsi4pk",
+          "KeyType": "HASH"
+        },
+        {
+          "AttributeName": "gsi4sk",
+          "KeyType": "RANGE"
+        }
+      ],
+      "Projection": {
+        "ProjectionType": "INCLUDE",
+        "NonKeyAttributes": ["exclude1", "exclude2", "exclude3", "__edb_e__", "__edb_v__"]
+      }
+    }
+  ],
+  "TableName": "projection-include",
+  "BillingMode": "PAY_PER_REQUEST"
+}

--- a/test/indexes.test-d.ts
+++ b/test/indexes.test-d.ts
@@ -259,3 +259,271 @@ async function main() {
       };
     });
 }
+
+const projectionEntity = new Entity({
+  model: {
+    entity: "projection",
+    version: "1",
+    service: "transactions",
+  },
+  attributes: {
+    id: { type: "string", required: true },
+    include1: { type: "string", required: true },
+    include2: { type: "boolean" },
+    include3: { type: "number" },
+    exclude1: { type: "string" },
+    exclude2: { type: "number" },
+    exclude3: { type: "boolean" },
+  },
+  indexes: {
+    primary: {
+      pk: {
+        field: "pk",
+        composite: ["id"],
+      },
+      sk: {
+        field: "sk",
+        composite: [],
+      },
+    },
+    includeIndex: {
+      index: "gsi1pk-gsi1sk-index",
+      project: ["include1", "include2", "include3"],
+      pk: {
+        field: "gsi1pk",
+        composite: ["id"],
+      },
+      sk: {
+        field: "gsi1sk",
+        composite: [],
+      },
+    },
+    thirdIndex: {
+      index: "gsi3pk-gsi3sk-index",
+      pk: {
+        field: "gsi3pk",
+        composite: ["id"],
+      },
+      sk: {
+        field: "gsi3sk",
+        composite: [],
+      },
+    },
+    excludeIndex: {
+      index: "gsi4pk-gsi4sk-index",
+      project: ["exclude1", "exclude2", "exclude3"],
+      pk: {
+        field: "gsi4pk",
+        composite: ["id"],
+      },
+      sk: {
+        field: "gsi4sk",
+        composite: [],
+      },
+    },
+    keysOnly: {
+      index: "gsi1pk-gsi1sk-index",
+      project: "keys_only",
+      pk: {
+        field: "gsi1pk",
+        composite: ["id"],
+      },
+      sk: {
+        field: "gsi1sk",
+        composite: [],
+      },
+    },
+  },
+});
+
+// scanning index with projected attributes should only return the projected attributes
+projectionEntity.scan.includeIndex.go().then((resp) => {
+  expectType<
+    {
+      include1: string;
+      include2?: boolean | undefined;
+      include3?: number | undefined;
+    }[]
+  >(resp.data);
+});
+
+// scanning index with projected attributes should only allow filtering on projected attributes
+projectionEntity.scan.includeIndex
+  .where((attrs, ops) => {
+    expectError(() => ops.eq(attrs.id, "1"));
+    return ops.eq(attrs.include1, "abc");
+  })
+  .go()
+  .then((resp) => {
+    expectType<
+      {
+        include1: string;
+        include2?: boolean | undefined;
+        include3?: number | undefined;
+      }[]
+    >(resp.data);
+  });
+
+// scanning index with projected attributes with hydrate should only allow filtering on projected attributes
+projectionEntity.scan.includeIndex
+  .where((attrs, ops) => {
+    expectError(() => ops.eq(attrs.id, "1"));
+    return ops.eq(attrs.include1, "abc");
+  })
+  .where((attrs, ops) => ops.eq(attrs.include2, true))
+  .go({ hydrate: true })
+  .then((resp) => {
+    expectType<
+      {
+        id: string;
+        include1: string;
+        include2?: boolean | undefined;
+        include3?: number | undefined;
+        exclude1?: string | undefined;
+        exclude2?: number | undefined;
+        exclude3?: boolean | undefined;
+      }[]
+    >(resp.data);
+  });
+
+// scanning index with projected attributes with hydrate should return user-provided attributes but not allow filtering on non-projected attributes
+projectionEntity.scan.includeIndex
+  .where((attrs, ops) => {
+    expectError(() => ops.eq(attrs.id, "1"));
+    return ops.eq(attrs.include1, "abc");
+  })
+  .where((attrs, ops) => ops.eq(attrs.include2, true))
+  .go({ hydrate: true, attributes: ["id"] })
+  .then((resp) => {
+    expectType<
+      {
+        id: string;
+      }[]
+    >(resp.data);
+  });
+
+// scanning index with projected items should not allow to specify non-projected attributes
+expectError(() =>
+  projectionEntity.scan.includeIndex.go({ attributes: ["id"] }),
+);
+
+// scanning index with projected items and hydrate should allow to specify non-projected attributes
+projectionEntity.scan.includeIndex
+  .where((attrs, ops) => ops.eq(attrs.include2, true))
+  .go({ hydrate: true, attributes: ["id", "include1"] })
+  .then((resp) => {
+    expectType<
+      {
+        id: string;
+        include1: string;
+      }[]
+    >(resp.data);
+  });
+
+// ==== QUERYING ====
+
+// querying index with projected attributes should only return the projected attributes
+projectionEntity.query
+  .includeIndex({ id: "1" })
+  .go()
+  .then((resp) => {
+    expectType<
+      {
+        include1: string;
+        include2?: boolean | undefined;
+        include3?: number | undefined;
+      }[]
+    >(resp.data);
+  });
+
+// querying index with projected attributes should only allow filtering on projected attributes
+projectionEntity.query
+  .includeIndex({ id: "1" })
+  .where((attrs, ops) => {
+    expectError(() => ops.eq(attrs.id, "1"));
+    return ops.eq(attrs.include1, "abc");
+  })
+  .where((attrs, ops) => ops.eq(attrs.include2, true))
+  .go({ hydrate: true, attributes: ["id"] })
+  .then((resp) => {
+    expectType<
+      {
+        id: string;
+      }[]
+    >(resp.data);
+  });
+
+// querying index with projected items should not allow to specify non-projected attributes
+expectError(() =>
+  projectionEntity.query.includeIndex({ id: "1" }).go({ attributes: ["id"] }),
+);
+
+// querying index with projected items and hydrate should allow to specify non-projected attributes
+projectionEntity.query
+  .includeIndex({ id: "1" })
+  .where((attrs, ops) => ops.eq(attrs.include2, true))
+  .go({ hydrate: true, attributes: ["id", "include1"] })
+  .then((resp) => {
+    expectType<
+      {
+        id: string;
+        include1: string;
+      }[]
+    >(resp.data);
+  });
+
+// quering index with projected attributes should only return the projected attributes
+projectionEntity.query
+  .includeIndex({ id: "1" })
+  .go()
+  .then((resp) => {
+    expectType<
+      {
+        include1: string;
+        include2?: boolean | undefined;
+        include3?: number | undefined;
+      }[]
+    >(resp.data);
+  });
+
+// scanning index with all projected attributes should return all attributes
+projectionEntity.scan.thirdIndex.go().then((resp) => {
+  expectType<
+    {
+      id: string;
+      include1: string;
+      include2?: boolean | undefined;
+      include3?: number | undefined;
+      exclude1?: string | undefined;
+      exclude2?: number | undefined;
+      exclude3?: boolean | undefined;
+    }[]
+  >(resp.data);
+});
+
+// scanning index with keys_only will return empty objects
+projectionEntity.scan.keysOnly.go().then((resp) => {
+  expectType<{}[]>(resp.data);
+});
+
+// scanning index with keys_only and hydrate will return all attributes
+projectionEntity.scan.keysOnly.go({ hydrate: true }).then((resp) => {
+  expectType<
+    {
+      id: string;
+      include1: string;
+      include2?: boolean | undefined;
+      include3?: number | undefined;
+      exclude1?: string | undefined;
+      exclude2?: number | undefined;
+      exclude3?: boolean | undefined;
+    }[]
+  >(resp.data);
+});
+
+// scanning index with keys_only does not allow filtering on any attributes
+expectError(() =>
+  projectionEntity.scan.keysOnly
+    .where((attrs, ops) => ops.eq(attrs.id, "1"))
+    .go(),
+);

--- a/test/init.js
+++ b/test/init.js
@@ -11,6 +11,8 @@ const localSecondaryIndexes = require("./definitions/localsecondaryindexes.json"
 const keysOnly = require("./definitions/keysonly.json");
 const castKeys = require("./definitions/castkeys.json");
 const reverseIndex = require("./definitions/reverseindex.json");
+const projectionInclude = require("./definitions/projection-include.json");
+const projectionIncludeWithoutEdb = require("./definitions/projection-include-without-edb.json");
 const shouldDestroy = process.argv.includes("--recreate");
 
 if (
@@ -80,6 +82,8 @@ async function main() {
     createTable(dynamodb, "electro_keysonly", keysOnly),
     createTable(dynamodb, "electro_castkeys", castKeys),
     createTable(dynamodb, "electro_reverseindex", reverseIndex),
+    createTable(dynamodb, "electro_projectioninclude", projectionInclude),
+    createTable(dynamodb, "electro_projectionincludewithoutedb", projectionIncludeWithoutEdb),
   ]);
 }
 

--- a/test/queries.test-d.ts
+++ b/test/queries.test-d.ts
@@ -37,7 +37,8 @@ class MockEntity<
   A extends string,
   F extends string,
   C extends string,
-  S extends Schema<A, F, C>,
+  S extends Schema<A, F, C, P>,
+  P extends string = string
 > {
   readonly schema: S;
 
@@ -49,8 +50,8 @@ class MockEntity<
     return {} as GoQueryTerminal<A, F, C, S, ResponseItem<A, F, C, S>>;
   }
 
-  getScanTerminal(): QueryRecordsGo<ResponseItem<A, F, C, S>> {
-    return {} as QueryRecordsGo<ResponseItem<A, F, C, S>>;
+  getScanTerminal(): QueryRecordsGo<ResponseItem<A, F, C, S>, S> {
+    return {} as QueryRecordsGo<ResponseItem<A, F, C, S>, S>;
   }
 
   // getPageQueryTerminal(): PageQueryTerminal<A,F,C,S, ResponseItem<A,F,C,S>, {abc: string}> {

--- a/www/src/config.ts
+++ b/www/src/config.ts
@@ -132,6 +132,10 @@ export const SIDEBAR: Sidebar = {
         text: "Using KEYS_ONLY Global Secondary Indexes",
         link: "en/recipes/keys-only-gsi",
       },
+      {
+        text: "Using INCLUDE Projection Global Secondary Indexes",
+        link: "en/recipes/include-projection-gsi",
+      },
     ],
   },
 };

--- a/www/src/pages/en/queries/scan.mdx
+++ b/www/src/pages/en/queries/scan.mdx
@@ -73,7 +73,21 @@ await StoreLocations.scan
 }
 ```
 
-## Execution Options
+## Scanning an Index
+
+You can also scan a specific index by using the access pattern as a method on the scan operation:
+
+```typescript
+await StoreLocations.scan.units.go();
+```
+
+### Use Cases
+
+Scanning an index is particularly useful when you have a [sparse index](/en/modeling/indexes#sparse-indexes) that you want to scan instead of scanning the entire table. 
+
+Sparse indexes contain only a subset of the table's items, making them more efficient for scanning when you're interested solely in the items present in the sparse index.
+
+When scanning an index, ElectroDB automatically adds the [`IndexName`](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html#:~:text=IndexName%20parameter) parameter to the DynamoDB scan request.
 
 import PartialExample from "../../../partials/query-options.mdx";
 

--- a/www/src/pages/en/recipes/include-projection-gsi.mdx
+++ b/www/src/pages/en/recipes/include-projection-gsi.mdx
@@ -1,0 +1,290 @@
+---
+title: Using INCLUDE Projection Global Secondary Indexes
+description: Querying indexes with INCLUDE projections for selective attribute access
+keywords:
+  - electrodb
+  - docs
+  - concepts
+  - dynamodb
+  - query
+  - entity
+  - attribute
+  - schema
+  - index
+  - include
+  - projection
+layout: ../../../layouts/MainLayout.astro
+---
+
+The `INCLUDE` projection type allows you to specify exactly which attributes are included in a Global Secondary Index. This provides a balance between the minimal storage of `KEYS_ONLY` and the complete data access of `ALL` projections. With `INCLUDE` projections, you can optimize your indexes by including only the attributes you need for your queries.
+
+## Example Setup
+
+<blockQuote>
+    <h4>Example Setup</h4>
+    <details>
+        <summary>Table Definition</summary>
+
+        ```json
+        {
+            "TableName": "electro",
+            "KeySchema": [
+                {
+                    "AttributeName": "pk",
+                    "KeyType": "HASH"
+                },
+                {
+                    "AttributeName": "sk",
+                    "KeyType": "RANGE"
+                }
+            ],
+            "AttributeDefinitions": [
+                {
+                    "AttributeName": "pk",
+                    "AttributeType": "S"
+                },
+                {
+                    "AttributeName": "sk",
+                    "AttributeType": "S"
+                },
+                {
+                    "AttributeName": "gsi1pk",
+                    "AttributeType": "S"
+                },
+                {
+                    "AttributeName": "gsi1sk",
+                    "AttributeType": "S"
+                }
+            ],
+            "GlobalSecondaryIndexes": [
+                {
+                    "IndexName": "gsi1pk-gsi1sk-index",
+                    "KeySchema": [
+                        {
+                            "AttributeName": "gsi1pk",
+                            "KeyType": "HASH"
+                        },
+                        {
+                            "AttributeName": "gsi1sk",
+                            "KeyType": "RANGE"
+                        }
+                    ],
+                    "Projection": {
+                        "ProjectionType": "INCLUDE",
+                        "NonKeyAttributes": ["name", "status", "createdAt", "__edb_e__", "__edb_v__"]
+                    }
+                }
+            ],
+            "BillingMode": "PAY_PER_REQUEST"
+        }
+        ```
+
+    </details>
+
+    <details>
+        <summary>Example Entity</summary>
+
+        ```typescript
+        import DynamoDB from "aws-sdk/clients/dynamodb";
+        import { Entity } from 'electrodb';
+
+        const client = new DynamoDB.DocumentClient();
+
+        const table = 'electro';
+
+        const tasks = new Entity({
+            model: {
+                entity: 'tasks',
+                version: '1',
+                service: 'taskapp'
+            },
+            attributes: {
+                taskId: {
+                    type: 'string'
+                },
+                projectId: {
+                    type: 'string'
+                },
+                name: {
+                    type: 'string'
+                },
+                description: {
+                    type: 'string'
+                },
+                status: {
+                    type: ['open', 'in-progress', 'closed'] as const,
+                    default: 'open'
+                },
+                priority: {
+                    type: 'number'
+                },
+                createdAt: {
+                    type: 'number',
+                    default: () => Date.now()
+                },
+                updatedAt: {
+                    type: 'number',
+                    watch: '*',
+                    set: () => Date.now()
+                }
+            },
+            indexes: {
+                tasks: {
+                    pk: {
+                        field: 'pk',
+                        composite: ['projectId']
+                    },
+                    sk: {
+                        field: 'sk',
+                        composite: ['taskId']
+                    }
+                },
+                statusIndex: {
+                    index: 'gsi1pk-gsi1sk-index',
+                    project: ['name', 'status', 'createdAt'],
+                    pk: {
+                        field: 'gsi1pk',
+                        composite: ['status'],
+                    },
+                    sk: {
+                        field: 'gsi1sk',
+                        composite: ['createdAt'],
+                    }
+                }
+        }
+    }, { table, client });
+    ```
+
+    </details>
+
+</blockQuote>
+
+## Using the Project Property
+
+When defining an index with an `INCLUDE` projection, you can use the `project` property in your ElectroDB entity definition to specify which attributes should be included in the index. This property maps to the `NonKeyAttributes` in the DynamoDB table definition.
+
+```typescript
+indexes: {
+    statusIndex: {
+        index: 'gsi1pk-gsi1sk-index',
+        project: ['name', 'status', 'createdAt'], // Only these attributes are included
+        pk: {
+            field: 'gsi1pk',
+            composite: ['status'],
+        },
+        sk: {
+            field: 'gsi1sk',
+            composite: ['createdAt'],
+        }
+    }
+}
+```
+
+## Querying INCLUDE Projections
+
+When querying an index with an `INCLUDE` projection, you can only access the attributes that were specified in the `project` array. ElectroDB will enforce this at the type level.
+
+### Basic Querying
+
+```typescript
+// Only returns the projected attributes: name, status, createdAt
+const { data, cursor } = await tasks.query
+  .statusIndex({ status: "open" })
+  .go();
+
+// data will only contain: { name: string, status: string, createdAt: number }[]
+```
+
+### Filtering on Projected Attributes
+
+You can only filter on attributes that are included in the projection:
+
+```typescript
+// ✅ This works - filtering on projected attributes
+const { data } = await tasks.query
+  .statusIndex({ status: "open" })
+  .where((attr, op) => op.eq(attr.name, "Important Task"))
+  .go();
+
+const { data } = await tasks.query
+  .statusIndex({ status: "open" })
+// ❌ This would not work - filtering on non-projected attributes
+  .where((attr, op) => op.eq(attr.description, "Some description"))
+  .go();
+```
+
+### Using Hydration
+
+If you need access to non-projected attributes, you can use the `hydrate` option to perform a follow-up `batchGet` operation:
+
+```typescript
+// With hydration, you get all attributes but can only filter on projected ones
+const { data } = await tasks.query
+  .statusIndex({ status: "open" })
+  .where((attr, op) => op.eq(attr.name, "Important Task"))
+  .go({ hydrate: true });
+
+// data will contain all attributes: { taskId, projectId, name, description, status, priority, createdAt, updatedAt }[]
+```
+
+### Selective Attribute Retrieval with Hydration
+
+When using hydration, you can still specify which attributes to return:
+
+```typescript
+const { data } = await tasks.query
+  .statusIndex({ status: "open" })
+  .where((attr, op) => op.eq(attr.name, "Important Task"))
+  .go({ 
+    hydrate: true, 
+    attributes: ['taskId', 'name', 'description'] 
+  });
+
+// data will only contain: { taskId: string, name: string, description: string }[]
+```
+
+## Benefits of INCLUDE Projections
+
+1. **Cost Optimization**: Only store the attributes you need in the index
+2. **Performance**: Smaller index size means faster queries
+3. **Multi-Filter Efficiency**: Create compact indexes for complex filtering patterns. When you have access patterns requiring many optional filters, projecting only necessary attributes creates a smaller "virtual table" that enables efficient multi-filter queries without scanning unnecessary data
+4. **Aggregation Optimization**: Smaller projected indexes are ideal for aggregation queries, reducing the number of requests needed and lowering costs by not scanning irrelevant attributes
+5. **Type Safety**: ElectroDB enforces which attributes are available at the type level
+
+## ⚠️ Critical Considerations
+
+### Entity Identifier Requirements
+
+When using `INCLUDE` projections, you **must** include ElectroDB's internal entity identifier attributes (`__edb_e__` and `__edb_v__`) in your projection. These attributes are essential for ElectroDB's multi-entity guardrail checks.
+
+**Option 1: Include Entity Identifiers (Recommended)**
+```typescript
+// In your DynamoDB table definition
+"Projection": {
+  "ProjectionType": "INCLUDE",
+  "NonKeyAttributes": ["name", "status", "createdAt", "__edb_e__", "__edb_v__"]
+}
+```
+
+**Option 2: Disable Ownership Checks (Use with Caution)**
+```typescript
+const { data } = await tasks.query
+  .statusIndex({ status: "open" })
+  .go({ ignoreOwnership: true });
+```
+
+⚠️ **Warning**: Using `ignoreOwnership: true` disables ElectroDB's entity validation. This means:
+- ElectroDB cannot verify that retrieved items belong to the correct entity
+- Version compatibility checks are disabled
+- You may receive items from different entities or incompatible versions
+- This can lead to unexpected behavior and data integrity issues
+
+### Other Considerations
+
+- **Filtering Limitations**: You can only filter on attributes that are included in the projection
+- **Hydration Overhead**: Using `hydrate: true` will perform additional `batchGet` operations
+
+## References
+
+- [DynamoDB GSI Projection Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Projection.html)
+- [Using KEYS_ONLY Global Secondary Indexes](/en/recipes/keys-only-gsi) 


### PR DESCRIPTION
Closes https://github.com/tywalch/electrodb/issues/508, https://github.com/tywalch/electrodb/issues/507
Currently, users who want to use DynamoDB indexes with the INCLUDE projection type do not receive any type safety from ElectroDB.

These indexes are highly beneficial for access patterns that require multiple optional filters, which a standard index cannot accommodate. By creating an index with only the attributes needed for the multi-filter access pattern, you can achieve much faster queries while scanning less data, resulting in lower costs.

It is also sometimes useful to scan a specific index when it is sparse and you are only interested in the items present in that index.

At present, ElectroDB does not offer a built-in type-safe method to scan an index.

This PR introduces two new features:  
-  A new option to specify the projected attributes of an index  
-  The ability to scan a specific index  
- You can combine the previous two features: scanning a sparse index with specific projected attributes in the index.

Here is an example of how to define projected attributes.

```typescript
indexes: {
    statusIndex: {
        index: 'gsi1pk-gsi1sk-index',
        project: ['name', 'status', 'createdAt'],
        pk: {
            field: 'gsi1pk',
            composite: ['status'],
        },
        sk: {
            field: 'gsi1sk',
            composite: ['createdAt'],
        }
    }
}
```

Here is an example of how to scan a specific index.

```
await StoreLocations.scan.units.go();
```

The PR primarily includes modifications at the type level to enhance type safety. Here is the type functionality:

1. Scanning or querying an index with limited projected attributes results in the output type containing only those projected attributes.
2. When scanning or querying an index with limited projected attributes, using the `attributes` argument in the go method allows you to specify only the projected attributes.
3. If you use the hydrate option while scanning or querying an index with limited projected attributes, the output type will include all of the entity’s attributes.
4. When using the hydrate option, you can specify any attributes of the entity in the `attributes` parameter while scanning or querying an index with limited projected attributes.
5. When scanning or querying an index with limited projected attributes, you can only filter by the projected attributes, regardless of whether you use the hydrate option.

## Implementation Overview

I introduced a new generic type `P` to the `Entity` and `Schema` to capture the type of the projected attributes. To ensure backward compatibility, the generic type has a default value of `string`, and the new generic is added as the last one (after `S`). 

This change allows users to migrate to the new version of the library without encountering type errors when using the Schema or Entity types.

To ensure that the output type of queries and index scans with limited projected attributes contains only the projected attributes, we forward the "access pattern" key to the `QueryBranches` and `GoQueryTerminalOptions` etc. This allows us to implement conditional types for achieving the fine-grained type safety described above.

## Notes

I added documentation, numerous tests, and type tests to validate all this functionality.

The new documentation explains that for INCLUDE indexes to work with ElectroDB, the user must add the `__edb_e__` and `__edb_v__` attributes or use the `ignoreOwnership` option.