### PR TITLE
Reduce ElectroDB pre/post-processing overhead before/after DynamoDB requests by up to 85%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -588,3 +588,6 @@ All notable changes to this project will be documented in this file. Breaking ch
 ## [3.4.3]
 ### Fixed
 - [Issue #439](https://github.com/tywalch/electrodb/issues/439); Fixed missing TypeScript types for `attributes` property on `scan`, `find`, and `match` methods.
+
+## [3.4.4]
+- Reduced ElectroDB's pre/post-processing overhead before/after DynamoDB requests by as much as 85% in some cases.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electrodb",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "electrodb",
-      "version": "3.4.3",
+      "version": "3.4.4",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/lib-dynamodb": "^3.654.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrodb",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "A library to more easily create and interact with multiple entities and heretical relationships in dynamodb",
   "main": "index.js",
   "scripts": {

--- a/src/util.js
+++ b/src/util.js
@@ -209,19 +209,16 @@ const cursorFormatter = {
 };
 
 function removeFixings({ prefix = "", postfix = "", value = "" } = {}) {
-  const start = value.toLowerCase().startsWith(prefix.toLowerCase())
-    ? prefix.length
-    : 0;
+  if (prefix === "" && postfix === "") return value;
+
+  const valueLower = value.toLowerCase();
+
+  const start = valueLower.startsWith(prefix.toLowerCase()) ? prefix.length : 0;
   const end =
     value.length -
-    (value.toLowerCase().endsWith(postfix.toLowerCase()) ? postfix.length : 0);
+    (valueLower.endsWith(postfix.toLowerCase()) ? postfix.length : 0);
 
-  let formatted = "";
-  for (let i = start; i < end; i++) {
-    formatted += value[i];
-  }
-
-  return formatted;
+  return value.slice(start, end);
 }
 
 function addPadding({ padding = {}, value = "" } = {}) {


### PR DESCRIPTION
I have noticed in my production environments using ElectroDB that there is sometimes over 100 ms of post-processing overhead caused by ElectroDB. This occurs when fetching 1MB of data from DynamoDB for an entity with dozens of attributes, nested objects, arrays etc. 

After examining the source code, I discovered a couple of interesting things:

### Prefix/Postfix Processing

After querying DynamoDB, ElectroDB formats the items before returning them to the user. This formatting includes calling the `removeFixings` function on every attribute, which removes certain prefixes and postfixes. The function previously used string concatenation; this PR replaces it with the `.slice(start, end)` method. This change immediately halved the post-processing time.

### Optimizations for `get`/`set` attribute callbacks
After querying DynamoDB, ElectroDB formats the items before returning them to the user. This formatting includes calling the `get` method on all attributes, allowing the user to change the attribute's value before it's returned to the consumer of the query. This happens for every attribute in an entity, regardless of whether the user defined a `get` method. 

During this `get` call, we pass the attribute's value along with the entire item to the function. To maintain immutability, we provide a shallow copy of the item with each `get` call. In a 1 MB response containing 200 items of 5 KB each, where each item has approximately 30 attributes, you would perform 6,000 shallow copies.

In this PR, we only evaluate the shallow copy of the object for a `get`/`set` callback on an attribute defined by the user. Using the previous example, if the entity lacks any `get` callbacks, those 6,000 shallow copies would never be evaluated. If a user has 2 `get` callbacks on the entity, you would only create 400 shallow copies.

## Final Result

I conducted a benchmark that replicates the production access patterns mentioned at the beginning of this PR. I scanned a table with 24 MB of data five times, resulting in a total of 120 requests. I measured the time ElectroDB takes to post-process each individual response, starting from when it receives the response from Dynamo in the `then` callback of the `Entity._exec` method until the consumer of the `Entity.scan.go()` receives the response. Each item is approximately 5 KB and contains dozens of attributes.

I ran this benchmark on AWS Lambda Node.js 20 with 1,777 MB of memory, which provides just over 1 vCPU.

Here is the consumer code:
```tsx
export async function handler() {
  for (let i = 0; i < 5; i++) {
    let cursor: string | undefined | null = undefined;
    do {
      const { cursor: nextCursor } = await MyEntity.scan.go({
        cursor,
      });
      console.timeEnd('electrodb processing');
      cursor = nextCursor;
    } while (cursor);
  }
}
```

Here are the post-processing measurements:

### Before the PR
-  Average: 109.31 ms
-  Minimum: 18.97 ms
-  Maximum: 249.83 ms
-  p90: 120.17 ms
-  p95: 121.99 ms
-  p99: 156.85 ms

### After the PR
-  Average: 15.34 ms - 85% reduction
-  Minimum: 4.42 ms - 76% reduction
-  Maximum: 48.85 ms - 80% reduction
-  p90: 19.56 ms - 83% reduction
-  p95: 23.48 ms - 80% reduction
-  p99: 36.20 ms - 76% reduction

Here is a line chart showing the post-processing duration for each request before and after the PR. You may notice a significant decrease in the post-processing duration, occurring five times in the benchmark. This is due to processing the last page in the pagination, which contains less than 1 MB of data.

<img width="1234" height="769" alt="image" src="https://github.com/user-attachments/assets/3e88a05c-1761-4470-a04b-d31ad8f0c892" />
