### PR TITLE
Docs: Fix relevant typo on Modeling/Indexes page

### DIFF
--- a/www/src/pages/en/modeling/indexes.mdx
+++ b/www/src/pages/en/modeling/indexes.mdx
@@ -393,7 +393,7 @@ const schema = {
 
 DynamoDB is a case-sensitive data store, and therefore it is common to convert the casing of keys to uppercase or lowercase prior to saving, updating, or querying data to your table. ElectroDB, by default, will lowercase all keys when preparing query parameters. For those who are using ElectroDB with an existing dataset, have preferences on upper or lowercase, or wish to not convert case at all, this can be configured on an index key field basis.
 
-In the example below, we are configuring the casing ElectroDB will use individually for the Partition Key and Sort Key on the GSI "gsi1". For the index's PK, mapped to `gsi1pk`, we ElectroDB will convert this key to uppercase prior to its use in queries. For the index's SK, mapped to `gsi1pk`, we ElectroDB will not convert the case of this key prior to its use in queries.
+In the example below, we are configuring the casing ElectroDB will use individually for the Partition Key and Sort Key on the GSI "gsi1". For the index's PK, mapped to `gsi1pk`, we ElectroDB will convert this key to uppercase prior to its use in queries. For the index's SK, mapped to `gsi1sk`, we ElectroDB will not convert the case of this key prior to its use in queries.
 
 ```typescript
 {


### PR DESCRIPTION
Corrects a mention of `pk` to `sk` where I think it might be a typo that could be confusing.

Before:
<img width="820" height="124" alt="image" src="https://github.com/user-attachments/assets/3883b1f6-3a97-4e2d-afc1-799ddac3a0c9" />
After:
<img width="827" height="121" alt="image" src="https://github.com/user-attachments/assets/7cb912d7-937f-4c69-bd49-2276bfdd22a2" />
