### PR TITLE
fix: introduces fix for Issue #343

### DIFF
--- a/examples/common/client.ts
+++ b/examples/common/client.ts
@@ -18,6 +18,10 @@ process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = "1";
 export const configuration = {
   endpoint: "http://localhost:8000",
   region: "us-east-1",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 };
 
 export const client = new DocumentClient(configuration);

--- a/src/clauses.js
+++ b/src/clauses.js
@@ -464,21 +464,19 @@ let clauses = {
             upsert.indexKey = indexKey;
 
             // only "set" data is used to make keys
-            const setFields = Object.entries(
-              entity.model.schema.translateToFields(setAttributes),
-            );
+            const setFields = entity.model.schema.translateToFields(setAttributes);
 
             // add the keys impacted except for the table index keys; they are upserted
             // automatically by dynamo
             for (const key in updatedKeys) {
               const value = updatedKeys[key];
               if (indexKey[key] === undefined) {
-                setFields.push([key, value]);
+                setFields[key] = value;
               }
             }
 
             entity._maybeApplyUpsertUpdate({
-              fields: setFields,
+              fields: Object.entries(setFields),
               operation: UpsertOperations.set,
               updateProxy,
               update,

--- a/test/connected.batch.spec.js
+++ b/test/connected.batch.spec.js
@@ -7,7 +7,11 @@ const ENTITY = "TEST_ENTITY";
 const DynamoDB = require("aws-sdk/clients/dynamodb");
 const client = new DynamoDB.DocumentClient({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 let schema = {
   model: {

--- a/test/connected.crud.spec.js
+++ b/test/connected.crud.spec.js
@@ -11,11 +11,19 @@ const DynamoDB = require("aws-sdk/clients/dynamodb");
 const v3DynamoDB = require("@aws-sdk/client-dynamodb");
 const v2Client = new DynamoDB.DocumentClient({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 const v3Client = new v3DynamoDB.DynamoDBClient({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 const print = (label, val) => console.log(label, JSON.stringify(val, null, 4));
 

--- a/test/connected.filters.spec.js
+++ b/test/connected.filters.spec.js
@@ -7,7 +7,11 @@ const uuidV4 = require("uuid").v4;
 const DynamoDB = require("aws-sdk/clients/dynamodb");
 const client = new DynamoDB.DocumentClient({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 
 describe("General", () => {

--- a/test/connected.issues.spec.js
+++ b/test/connected.issues.spec.js
@@ -7,6 +7,10 @@ const table = "electro";
 const client = new DynamoDB.DocumentClient({
   region: "us-east-1",
   endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 
 describe("Issue #85", () => {

--- a/test/connected.issues.spec.ts
+++ b/test/connected.issues.spec.ts
@@ -1,0 +1,195 @@
+// @ts-nocheck
+process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = 1;
+import DynamoDB from "aws-sdk/clients/dynamodb";
+import { v4 as uuid } from "uuid";
+import { expect } from "chai";
+import { Entity } from "../";
+const table = "electro";
+const client = new DynamoDB.DocumentClient({
+  region: "us-east-1",
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
+});
+
+describe("Issue #343", () => {
+  function createEntity() {
+    return new Entity({
+      model: {
+        service: uuid(),
+        entity: uuid(),
+        version: "1",
+      },
+      attributes: {
+        accountId: { type: "string", required: true },
+        transactionId: { type: "string", required: true },
+        date: { type: "string" },
+        value: { type: "string" },
+      },
+      indexes: {
+        byId: {
+          index: "gsi1pk-index",
+          pk: {
+            field: "gsi1pk",
+            composite: ["transactionId"],
+          },
+          sk: {
+              field: "gsi1sk",
+              composite: [],
+          }
+        },
+        byAccount: {
+          pk: {
+            field: "pk",
+            composite: ["accountId"],
+          },
+          sk: {
+            field: "sk",
+            composite: ["date", "transactionId"],
+          },
+        },
+        byAccountDate: {
+          index: "accountId-date-index",
+          pk: {
+            field: "accountId",
+            composite: ["accountId"],
+    
+          },
+          sk: {
+            field: "value",
+            composite: ["value"],
+          },
+        },
+      }
+    }, {table, client});
+  }
+
+  it(`should upsert item without duplicating attribute reference for value`, async () => {
+    const inventory = createEntity();
+    const accountId = uuid();
+    const transactionId = uuid();
+    const date = "2024-03-14";
+    const value = "123";
+
+    const item = {
+      accountId: accountId,
+      transactionId: transactionId,
+      date: date,
+      value: value,
+    };
+
+    const params = inventory.upsert(item).params();
+
+    expect(params).to.deep.equal({
+      "TableName": table,
+      "UpdateExpression": "SET #__edb_e__ = :__edb_e___u0, #__edb_v__ = :__edb_v___u0, #accountId = :accountId_u0, #transactionId = :transactionId_u0, #date = :date_u0, #value = :value_u0, #gsi1pk = :gsi1pk_u0, #gsi1sk = :gsi1sk_u0",
+      "ExpressionAttributeNames": {
+          "#__edb_e__": "__edb_e__",
+          "#__edb_v__": "__edb_v__",
+          "#accountId": "accountId",
+          "#transactionId": "transactionId",
+          "#date": "date",
+          "#value": "value",
+          "#gsi1pk": "gsi1pk",
+          "#gsi1sk": "gsi1sk",
+      },
+      "ExpressionAttributeValues": {
+          ":__edb_e___u0": inventory.model.entity,
+          ":__edb_v___u0": inventory.model.version,
+          ":accountId_u0": accountId,
+          ":transactionId_u0": transactionId,
+          ":date_u0": date,
+          ":value_u0": value,
+          ":gsi1pk_u0": `$${inventory.model.service}#transactionid_${transactionId}`,
+          ":gsi1sk_u0": `$${inventory.model.entity}_${inventory.model.version}`
+      },
+      "Key": {
+          "pk": `$${inventory.model.service}#accountid_${accountId}`,
+          "sk": `$${inventory.model.entity}_${inventory.model.version}#date_${date}#transactionid_${transactionId}`
+      }   
+    });
+    
+    await inventory.upsert(item).go();
+  });
+
+  it(`should update item without duplicating attribute reference for value`, async () => {
+    const inventory = createEntity();
+    const accountId = uuid();
+    const transactionId = uuid();
+    const date = "2024-03-14";
+    const value = "123";
+
+    await inventory.update({ transactionId, date, accountId }).set({ value }).go();
+    const params = inventory.update({ transactionId, date, accountId }).set({ value }).params();
+    expect(params).to.deep.equal({
+      "TableName": table,
+      "UpdateExpression": "SET #value = :value_u0, #accountId = :accountId_u0, #date = :date_u0, #transactionId = :transactionId_u0, #__edb_e__ = :__edb_e___u0, #__edb_v__ = :__edb_v___u0",
+      "ExpressionAttributeNames": {
+        "#__edb_e__": "__edb_e__",
+        "#__edb_v__": "__edb_v__",
+        "#accountId": "accountId",
+        "#transactionId": "transactionId",
+        "#date": "date",
+        "#value": "value",
+      },
+      "ExpressionAttributeValues": {
+        ":__edb_e___u0": inventory.model.entity,
+        ":__edb_v___u0": inventory.model.version,
+        ":accountId_u0": accountId,
+        ":transactionId_u0": transactionId,
+        ":date_u0": date,
+        ":value_u0": value,
+      },
+      "Key": {
+        "pk": `$${inventory.model.service}#accountid_${accountId}`,
+        "sk": `$${inventory.model.entity}_${inventory.model.version}#date_${date}#transactionid_${transactionId}`
+      }
+    });
+  });
+
+  it(`should patch item without duplicating attribute reference for value`, async () => {
+    const inventory = createEntity();
+    const accountId = uuid();
+    const transactionId = uuid();
+    const date = "2024-03-14";
+    const value = "123";
+
+    const item = {
+      accountId: accountId,
+      transactionId: transactionId,
+      date: date,
+    };
+    await inventory.put(item).go();
+    await inventory.patch({ transactionId, date, accountId }).set({ value }).go();
+    const params = inventory.patch({ transactionId, date, accountId }).set({ value }).params();
+    expect(params).to.deep.equal({
+      "TableName": table,
+      "UpdateExpression": "SET #value = :value_u0, #accountId = :accountId_u0, #date = :date_u0, #transactionId = :transactionId_u0, #__edb_e__ = :__edb_e___u0, #__edb_v__ = :__edb_v___u0",
+      "ExpressionAttributeNames": {
+        "#__edb_e__": "__edb_e__",
+        "#__edb_v__": "__edb_v__",
+        "#accountId": "accountId",
+        "#transactionId": "transactionId",
+        "#date": "date",
+        "#value": "value",
+        "#pk": "pk",
+        "#sk": "sk",
+      },
+      "ExpressionAttributeValues": {
+        ":__edb_e___u0": inventory.model.entity,
+        ":__edb_v___u0": inventory.model.version,
+        ":accountId_u0": accountId,
+        ":transactionId_u0": transactionId,
+        ":date_u0": date,
+        ":value_u0": value,
+      },
+      "ConditionExpression": "attribute_exists(#pk) AND attribute_exists(#sk)",
+      "Key": {
+        "pk": `$${inventory.model.service}#accountid_${accountId}`,
+        "sk": `$${inventory.model.entity}_${inventory.model.version}#date_${date}#transactionid_${transactionId}`
+      }
+    });
+  });
+});

--- a/test/connected.page.spec.js
+++ b/test/connected.page.spec.js
@@ -6,11 +6,14 @@ const c = require("../src/client");
 const { cursorFormatter } = require("../src/util");
 const { Entity, Service } = require("../");
 
-const endpoint = process.env.LOCAL_DYNAMO_ENDPOINT;
-const region = "us-east-1";
-const isLocal = endpoint !== undefined;
-
-AWS.config.update({ region, endpoint });
+AWS.config.update({ 
+  region: "us-east-1",
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
+ });
 
 const client = new AWS.DynamoDB.DocumentClient();
 const table = "electro";
@@ -279,7 +282,7 @@ Tasks.sentences =
   );
 
 describe("Query Pagination", () => {
-  const total = isLocal ? 500 : 100;
+  const total = 500;
 
   const tasks = new Tasks(TasksModel, { client, table });
   const tasks2 = new Tasks(makeTasksModel(), { client, table });

--- a/test/connected.service.spec.js
+++ b/test/connected.service.spec.js
@@ -9,7 +9,11 @@ const table = "electro";
 
 const client = new DynamoDB.DocumentClient({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 
 let modelOne = {

--- a/test/connected.update.spec.js
+++ b/test/connected.update.spec.js
@@ -7,7 +7,11 @@ const DynamoDB = require("aws-sdk/clients/dynamodb");
 
 const client = new DynamoDB.DocumentClient({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 
 const table = "electro";

--- a/test/connected.where.spec.js
+++ b/test/connected.where.spec.js
@@ -6,7 +6,11 @@ const uuidV4 = require("uuid").v4;
 const DynamoDB = require("aws-sdk/clients/dynamodb");
 const client = new DynamoDB.DocumentClient({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 
 describe("Where Clause Queries", () => {

--- a/test/init.js
+++ b/test/init.js
@@ -23,8 +23,12 @@ if (
 }
 
 const configuration = {
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT || "http://localhost:8000",
   region: "us-east-1",
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 };
 
 const dynamodb = new DynamoDB(configuration);

--- a/test/offline.service.spec.js
+++ b/test/offline.service.spec.js
@@ -4,7 +4,11 @@ const { expect } = require("chai");
 const DynamoDB = require("aws-sdk/clients/dynamodb");
 const client = new DynamoDB.DocumentClient({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 
 let modelOne = {

--- a/test/offline.util.spec.js
+++ b/test/offline.util.spec.js
@@ -1,5 +1,5 @@
 const { expect } = require("chai");
-const { removeFixings, removeJSONPath } = require("../src/util");
+const { removeFixings } = require("../src/util");
 
 describe("removeFixings", () => {
   it("should remove only a prefix", () => {

--- a/test/ts_connected.client.spec.ts
+++ b/test/ts_connected.client.spec.ts
@@ -11,12 +11,20 @@ const table = "electro";
 
 const v2Client = new V2Client({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 
 const v3Client = new V3Client({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 
 const clients = [

--- a/test/ts_connected.complex.spec.ts
+++ b/test/ts_connected.complex.spec.ts
@@ -5,7 +5,11 @@ import DynamoDB from "aws-sdk/clients/dynamodb";
 import { v4 as uuid } from "uuid";
 const client = new DynamoDB.DocumentClient({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 
 const table = "electro";

--- a/test/ts_connected.crud.spec.ts
+++ b/test/ts_connected.crud.spec.ts
@@ -15,7 +15,11 @@ import DynamoDB from "aws-sdk/clients/dynamodb";
 
 const client = new DynamoDB.DocumentClient({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 
 const sleep = async (ms: number) =>

--- a/test/ts_connected.entity.spec.ts
+++ b/test/ts_connected.entity.spec.ts
@@ -26,8 +26,12 @@ type ConversionTest = {
 const conversionTests: ConversionTest[] = require("./conversions");
 
 const client = new DocumentClient({
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
   region: "us-east-1",
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 
 const table = "electro";

--- a/test/ts_connected.hydration.spec.ts
+++ b/test/ts_connected.hydration.spec.ts
@@ -7,7 +7,11 @@ import DynamoDB from "aws-sdk/clients/dynamodb";
 
 const client = new DynamoDB.DocumentClient({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 
 const createItems = <T>(

--- a/test/ts_connected.logger.spec.ts
+++ b/test/ts_connected.logger.spec.ts
@@ -11,7 +11,11 @@ const DynamoDB = require("aws-sdk/clients/dynamodb");
 const table = "electro";
 const client = new DynamoDB.DocumentClient({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 
 type TestLoggerEvents = Map<string, ElectroEvent[]>;

--- a/test/ts_connected.service.spec.ts
+++ b/test/ts_connected.service.spec.ts
@@ -6,7 +6,11 @@ import { v4 as uuid } from "uuid";
 
 const client = new DynamoDB.DocumentClient({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 
 type DocClient = typeof client;

--- a/test/ts_connected.transaction.spec.ts
+++ b/test/ts_connected.transaction.spec.ts
@@ -205,12 +205,20 @@ const c = require("../src/client");
 
 const v2Client = new V2Client({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 
 const v3Client = new V3Client({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 
 const clients = [

--- a/test/ts_connected.update.spec.ts
+++ b/test/ts_connected.update.spec.ts
@@ -8,7 +8,11 @@ import DynamoDB from "aws-sdk/clients/dynamodb";
 
 const client = new DynamoDB.DocumentClient({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 
 function print(label: string, val: any): void;

--- a/test/ts_connected.validations.spec.ts
+++ b/test/ts_connected.validations.spec.ts
@@ -5,7 +5,11 @@ import { v4 as uuid } from "uuid";
 import DynamoDB from "aws-sdk/clients/dynamodb";
 const client = new DynamoDB.DocumentClient({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 const table = "electro_nosort";
 

--- a/test/ts_connected.where.spec.ts
+++ b/test/ts_connected.where.spec.ts
@@ -12,7 +12,11 @@ import { v4 as uuid } from "uuid";
 import DynamoDB from "aws-sdk/clients/dynamodb";
 const client = new DynamoDB.DocumentClient({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
 });
 
 const table = "electro";


### PR DESCRIPTION
fixes #343 
- Introduced a new test file for Issue #343 to validate upsert functionality without duplicating attribute references.
- Added credentials (accessKeyId and secretAccessKey) to the DocumentClient configuration across multiple test files and examples.
- Updated endpoint handling to use a default value of "http://localhost:8000" if LOCAL_DYNAMO_ENDPOINT is not defined.
- Refactored setFields handling in clauses.js to improve key management during upsert operations.