### PR TITLE
Fix empty sort key condition isolation issue

### DIFF
--- a/src/entity.js
+++ b/src/entity.js
@@ -3785,8 +3785,9 @@ class Entity {
           this.model.facets.labels[index] &&
           Array.isArray(this.model.facets.labels[index].sk);
         let labels = hasLabels ? this.model.facets.labels[index].sk : [];
+        const hasFacets = Object.keys(skFacet).length > 0;
         let sortKey = this._makeKey(prefixes.sk, facets.sk, skFacet, labels, {
-          excludeLabelTail: true,
+          excludeLabelTail: hasFacets,
           excludePostfix,
           transform,
         });

--- a/test/offline.entity.spec.js
+++ b/test/offline.entity.spec.js
@@ -213,7 +213,7 @@ describe("Entity", () => {
               ExpressionAttributeNames: { "#pk": "pk", "#sk1": "sk" },
               ExpressionAttributeValues: {
                 ":pk": "$test_1#prop1_val1#prop2_val2",
-                ":sk1": "$collectiona#entityone",
+                ":sk1": "$collectiona#entityone#prop3_",
               },
               KeyConditionExpression: "#pk = :pk and #sk1 > :sk1",
             },
@@ -222,7 +222,7 @@ describe("Entity", () => {
               ExpressionAttributeNames: { "#pk": "pk", "#sk1": "sk" },
               ExpressionAttributeValues: {
                 ":pk": "$test_1#prop1_val1#prop2_val2",
-                ":sk1": "$collectiona#entityone",
+                ":sk1": "$collectiona#entityone#prop3_",
               },
               KeyConditionExpression: "#pk = :pk and #sk1 < :sk1",
             },
@@ -231,7 +231,7 @@ describe("Entity", () => {
               ExpressionAttributeNames: { "#pk": "pk", "#sk1": "sk" },
               ExpressionAttributeValues: {
                 ":pk": "$test_1#prop1_val1#prop2_val2",
-                ":sk1": "$collectiona#entityone",
+                ":sk1": "$collectiona#entityone#prop3_",
               },
               KeyConditionExpression: "#pk = :pk and #sk1 >= :sk1",
             },
@@ -240,7 +240,7 @@ describe("Entity", () => {
               ExpressionAttributeNames: { "#pk": "pk", "#sk1": "sk" },
               ExpressionAttributeValues: {
                 ":pk": "$test_1#prop1_val1#prop2_val2",
-                ":sk1": "$collectiona#entityone",
+                ":sk1": "$collectiona#entityone#prop3_",
               },
               KeyConditionExpression: "#pk = :pk and #sk1 <= :sk1",
             },
@@ -259,7 +259,7 @@ describe("Entity", () => {
               ExpressionAttributeNames: { "#pk": "pk", "#sk1": "sk" },
               ExpressionAttributeValues: {
                 ":pk": "$test_1#prop1_val1#prop2_val2",
-                ":sk1": "$collectiona#entityone",
+                ":sk1": "$collectiona#entityone#prop3_",
               },
             },
             between: {
@@ -267,8 +267,8 @@ describe("Entity", () => {
               ExpressionAttributeNames: { "#pk": "pk", "#sk1": "sk" },
               ExpressionAttributeValues: {
                 ":pk": "$test_1#prop1_val1#prop2_val2",
-                ":sk1": "$collectiona#entityone",
-                ":sk2": "$collectiona#entityone",
+                ":sk1": "$collectiona#entityone#prop3_",
+                ":sk2": "$collectiona#entityone#prop3_",
               },
               KeyConditionExpression:
                 "#pk = :pk and #sk1 BETWEEN :sk1 AND :sk2",


### PR DESCRIPTION
When comparison queries (gt, lt, etc.) were called with an empty object,
the sort key prefix omitted the first composite attribute label (e.g.,
"$tasks_1" instead of "$tasks_1#team_"). This caused queries to
incorrectly match items across different entity versions, breaking
entity isolation.

Fixed by checking if composite attributes are provided before setting
excludeLabelTail in _makeIndexKeysWithoutTail.