### PR TITLE
feat(#545): add `abortSignal` support to go() query options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -621,7 +621,7 @@ All notable changes to this project will be documented in this file. Breaking ch
 - [Issue #540](https://github.com/tywalch/electrodb/issues/540) Rolls back a change introduced in 3.5.0 (via [533](https://github.com/tywalch/electrodb/pull/533/)) that caused over-filtering in collection queries, resulting in some collection members not being returned.
 
 ## [3.6.0]
-### Added
+### Added 
 - [Issue #507](https://github.com/tywalch/electrodb/issues/507); You can now scan an index. [See docs](https://electrodb.dev/en/queries/scan/#scanning-an-index) Contribution provided by [@anatolzak](https://github.com/anatolzak)
 - [Issue #508](https://github.com/tywalch/electrodb/issues/508); Added support for INCLUDE projection type in index definitions, allowing selective attribute projection for optimized query performance and cost reduction. [See docs](https://electrodb.dev/en/recipes/include-projection-gsi) Contribution provided by [@anatolzak](https://github.com/anatolzak)
 
@@ -631,7 +631,7 @@ All notable changes to this project will be documented in this file. Breaking ch
 
 ## [3.6.2]
 ### Added
-- Fast follow to 3.6.0, relaxes projection attribute constraint on collection entities. 3.6.0 required [collection] member entities to all share the same attributes when using a `projection` defined index. This constraint came from the original scope of 3.6.0. Thankfully, due to the work of [@anatolzak](https://github.com/anatolzak), 3.6.0 shipped with robust collection typing and this no longer was a concern.
+- Fast follow to 3.6.0, relaxes projection attribute constraint on collection entities. 3.6.0 required [collection] member entities to all share the same attributes when using a `projection` defined index. This constraint came from the original scope of 3.6.0. Thankfully, due to the work of [@anatolzak](https://github.com/anatolzak), 3.6.0 shipped with robust collection typing and this no longer was a concern. 
 
 ## [3.7.0]
 ### Adds support for [multi-attribute indexes](https://aws.amazon.com/blogs/database/multi-key-support-for-global-secondary-index-in-amazon-dynamodb/) [read more](https://electrodb.dev/en/modeling/indexes/#multi-attribute-indexes).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -621,7 +621,7 @@ All notable changes to this project will be documented in this file. Breaking ch
 - [Issue #540](https://github.com/tywalch/electrodb/issues/540) Rolls back a change introduced in 3.5.0 (via [533](https://github.com/tywalch/electrodb/pull/533/)) that caused over-filtering in collection queries, resulting in some collection members not being returned.
 
 ## [3.6.0]
-### Added 
+### Added
 - [Issue #507](https://github.com/tywalch/electrodb/issues/507); You can now scan an index. [See docs](https://electrodb.dev/en/queries/scan/#scanning-an-index) Contribution provided by [@anatolzak](https://github.com/anatolzak)
 - [Issue #508](https://github.com/tywalch/electrodb/issues/508); Added support for INCLUDE projection type in index definitions, allowing selective attribute projection for optimized query performance and cost reduction. [See docs](https://electrodb.dev/en/recipes/include-projection-gsi) Contribution provided by [@anatolzak](https://github.com/anatolzak)
 
@@ -631,7 +631,7 @@ All notable changes to this project will be documented in this file. Breaking ch
 
 ## [3.6.2]
 ### Added
-- Fast follow to 3.6.0, relaxes projection attribute constraint on collection entities. 3.6.0 required [collection] member entities to all share the same attributes when using a `projection` defined index. This constraint came from the original scope of 3.6.0. Thankfully, due to the work of [@anatolzak](https://github.com/anatolzak), 3.6.0 shipped with robust collection typing and this no longer was a concern. 
+- Fast follow to 3.6.0, relaxes projection attribute constraint on collection entities. 3.6.0 required [collection] member entities to all share the same attributes when using a `projection` defined index. This constraint came from the original scope of 3.6.0. Thankfully, due to the work of [@anatolzak](https://github.com/anatolzak), 3.6.0 shipped with robust collection typing and this no longer was a concern.
 
 ## [3.7.0]
 ### Adds support for [multi-attribute indexes](https://aws.amazon.com/blogs/database/multi-key-support-for-global-secondary-index-in-amazon-dynamodb/) [read more](https://electrodb.dev/en/modeling/indexes/#multi-attribute-indexes).
@@ -654,3 +654,7 @@ All notable changes to this project will be documented in this file. Breaking ch
 
 ## [3.7.5]
 - [Issue #554](https://github.com/tywalch/electrodb/issues/554); Fixed `hydrate: true` returning no items when querying composite type indexes with `keys_only` or `include` projections.
+
+## [3.8.0]
+### Added
+- [Issue #545](https://github.com/tywalch/electrodb/issues/545); Added support for passing an `abortSignal` to the `go()` query options, allowing users to cancel in-flight DynamoDB requests.

--- a/index.d.ts
+++ b/index.d.ts
@@ -2652,6 +2652,7 @@ export interface QueryOptions {
   order?: "asc" | "desc";
   consistent?: boolean;
   client?: DocumentClient;
+  abortSignal?: AbortSignal;
 }
 
 // subset of QueryOptions
@@ -2742,6 +2743,7 @@ interface GoBatchGetTerminalOptions<Attributes> {
   logger?: ElectroEventListener;
   consistent?: boolean;
   client?: DocumentClient;
+  abortSignal?: AbortSignal;
 }
 
 export type ExecutionOptionCompare = "keys" | "attributes" | "v2";
@@ -2774,6 +2776,7 @@ type ServiceQueryGoTerminalOptions<
   order?: "asc" | "desc";
   consistent?: boolean;
   client?: DocumentClient;
+  abortSignal?: AbortSignal;
 } & QueryExecutionComparisonParts &
   (
     | {
@@ -2843,6 +2846,7 @@ type GoQueryTerminalOptions<
   hydrate?: boolean;
   consistent?: boolean;
   client?: DocumentClient;
+  abortSignal?: AbortSignal;
 } & QueryExecutionComparisonParts &
   (
     | {
@@ -2871,6 +2875,7 @@ interface TransactWriteQueryOptions {
   logger?: ElectroEventListener;
   response?: "all_old";
   client?: DocumentClient;
+  abortSignal?: AbortSignal;
 }
 
 interface TransactGetQueryOptions<Attributes> {
@@ -2884,6 +2889,7 @@ interface TransactGetQueryOptions<Attributes> {
   logger?: ElectroEventListener;
   consistent?: boolean;
   client?: DocumentClient;
+  abortSignal?: AbortSignal;
 }
 
 export type ParamTerminalOptions<Attributes> = {
@@ -5990,12 +5996,14 @@ type TransactWriteFunctionOptions = {
   token?: string;
   logger?: ElectroEventListener;
   client?: DocumentClient;
+  abortSignal?: AbortSignal;
 };
 
 type TransactGetFunctionOptions = {
   token?: string;
   logger?: ElectroEventListener;
   client?: DocumentClient;
+  abortSignal?: AbortSignal;
 };
 
 type TransactWriteExtractedType<

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electrodb",
-  "version": "3.7.5",
+  "version": "3.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "electrodb",
-      "version": "3.7.5",
+      "version": "3.8.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/lib-dynamodb": "^3.654.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrodb",
-  "version": "3.7.5",
+  "version": "3.8.0",
   "description": "A library to more easily create and interact with multiple entities and heretical relationships in dynamodb",
   "main": "index.js",
   "scripts": {

--- a/src/client.js
+++ b/src/client.js
@@ -49,39 +49,94 @@ class DocumentClientV2Wrapper {
     this.__v = "v2";
   }
 
-  get(params) {
-    return this.client.get(params);
+  _wrapRequest(request, signal) {
+    return {
+      promise: () => {
+        return new Promise((resolve, reject) => {
+          if (signal && signal.aborted) {
+            request.abort();
+            return reject(
+              new ElectroError(
+                ErrorCodes.OperationAborted,
+                "The operation was aborted",
+              ),
+            );
+          }
+
+          const onAbort = () => {
+            request.abort();
+            reject(
+              new ElectroError(
+                ErrorCodes.OperationAborted,
+                "The operation was aborted",
+              ),
+            );
+          };
+
+          if (signal) {
+            signal.addEventListener("abort", onAbort, { once: true });
+          }
+
+          request
+            .promise()
+            .then((result) => {
+              if (signal) {
+                signal.removeEventListener("abort", onAbort);
+              }
+              resolve(result);
+            })
+            .catch((err) => {
+              if (signal) {
+                signal.removeEventListener("abort", onAbort);
+              }
+              reject(err);
+            });
+        });
+      },
+    };
   }
 
-  put(params) {
-    return this.client.put(params);
+  get(params, options = {}) {
+    const request = this.client.get(params);
+    return this._wrapRequest(request, options.abortSignal);
   }
 
-  update(params) {
-    return this.client.update(params);
+  put(params, options = {}) {
+    const request = this.client.put(params);
+    return this._wrapRequest(request, options.abortSignal);
   }
 
-  delete(params) {
-    return this.client.delete(params);
+  update(params, options = {}) {
+    const request = this.client.update(params);
+    return this._wrapRequest(request, options.abortSignal);
   }
 
-  batchWrite(params) {
-    return this.client.batchWrite(params);
+  delete(params, options = {}) {
+    const request = this.client.delete(params);
+    return this._wrapRequest(request, options.abortSignal);
   }
 
-  batchGet(params) {
-    return this.client.batchGet(params);
+  batchWrite(params, options = {}) {
+    const request = this.client.batchWrite(params);
+    return this._wrapRequest(request, options.abortSignal);
   }
 
-  scan(params) {
-    return this.client.scan(params);
+  batchGet(params, options = {}) {
+    const request = this.client.batchGet(params);
+    return this._wrapRequest(request, options.abortSignal);
   }
 
-  query(params) {
-    return this.client.query(params);
+  scan(params, options = {}) {
+    const request = this.client.scan(params);
+    return this._wrapRequest(request, options.abortSignal);
   }
 
-  _transact(transactionRequest) {
+  query(params, options = {}) {
+    const request = this.client.query(params);
+    return this._wrapRequest(request, options.abortSignal);
+  }
+
+  _transact(transactionRequest, signal) {
     let cancellationReasons;
     transactionRequest.on("extractError", (response) => {
       try {
@@ -92,34 +147,72 @@ class DocumentClientV2Wrapper {
     });
 
     return {
-      async promise() {
-        return transactionRequest.promise().catch((err) => {
-          if (err) {
-            if (Array.isArray(cancellationReasons)) {
-              return {
-                canceled: cancellationReasons.map((reason) => {
-                  if (reason.Item) {
-                    return unmarshallItem(reason);
-                  }
-                  return reason;
-                }),
-              };
-            }
-            throw err;
+      promise: () => {
+        return new Promise((resolve, reject) => {
+          if (signal && signal.aborted) {
+            transactionRequest.abort();
+            return reject(
+              new ElectroError(
+                ErrorCodes.OperationAborted,
+                "The operation was aborted",
+              ),
+            );
           }
+
+          const onAbort = () => {
+            transactionRequest.abort();
+            reject(
+              new ElectroError(
+                ErrorCodes.OperationAborted,
+                "The operation was aborted",
+              ),
+            );
+          };
+
+          if (signal) {
+            signal.addEventListener("abort", onAbort, { once: true });
+          }
+
+          transactionRequest
+            .promise()
+            .then((result) => {
+              if (signal) {
+                signal.removeEventListener("abort", onAbort);
+              }
+              resolve(result);
+            })
+            .catch((err) => {
+              if (signal) {
+                signal.removeEventListener("abort", onAbort);
+              }
+              if (err) {
+                if (Array.isArray(cancellationReasons)) {
+                  resolve({
+                    canceled: cancellationReasons.map((reason) => {
+                      if (reason.Item) {
+                        return unmarshallItem(reason);
+                      }
+                      return reason;
+                    }),
+                  });
+                } else {
+                  reject(err);
+                }
+              }
+            });
         });
       },
     };
   }
 
-  transactWrite(params) {
+  transactWrite(params, options = {}) {
     const transactionRequest = this.client.transactWrite(params);
-    return this._transact(transactionRequest);
+    return this._transact(transactionRequest, options.abortSignal);
   }
 
-  transactGet(params) {
+  transactGet(params, options = {}) {
     const transactionRequest = this.client.transactGet(params);
-    return this._transact(transactionRequest);
+    return this._transact(transactionRequest, options.abortSignal);
   }
 
   createSet(value, ...rest) {
@@ -142,68 +235,89 @@ class DocumentClientV3Wrapper {
     this.__v = "v3";
   }
 
-  promiseWrap(fn) {
+  promiseWrap(fn, signal) {
     return {
       promise: async () => {
-        return fn();
+        if (signal && signal.aborted) {
+          throw new ElectroError(
+            ErrorCodes.OperationAborted,
+            "The operation was aborted",
+          );
+        }
+        try {
+          return await fn();
+        } catch (err) {
+          if (
+            !!err &&
+            typeof err === "object" &&
+            err.name === "AbortError" ||
+            (signal && signal.aborted)
+          ) {
+            throw new ElectroError(
+              ErrorCodes.OperationAborted,
+              "The operation was aborted",
+            );
+          }
+          throw err;
+        }
       },
     };
   }
 
-  get(params) {
+  get(params, options = {}) {
     return this.promiseWrap(() => {
       const command = new this.lib.GetCommand(params);
-      return this.client.send(command);
-    });
+      return this.client.send(command, { abortSignal: options.abortSignal });
+    }, options.abortSignal);
   }
-  put(params) {
+  put(params, options = {}) {
     return this.promiseWrap(() => {
       const command = new this.lib.PutCommand(params);
-      return this.client.send(command);
-    });
+      return this.client.send(command, { abortSignal: options.abortSignal });
+    }, options.abortSignal);
   }
-  update(params) {
+  update(params, options = {}) {
     return this.promiseWrap(() => {
       const command = new this.lib.UpdateCommand(params);
-      return this.client.send(command);
-    });
+      return this.client.send(command, { abortSignal: options.abortSignal });
+    }, options.abortSignal);
   }
-  delete(params) {
-    return this.promiseWrap(async () => {
+  delete(params, options = {}) {
+    return this.promiseWrap(() => {
       const command = new this.lib.DeleteCommand(params);
-      return this.client.send(command);
-    });
+      return this.client.send(command, { abortSignal: options.abortSignal });
+    }, options.abortSignal);
   }
-  batchWrite(params) {
-    return this.promiseWrap(async () => {
+  batchWrite(params, options = {}) {
+    return this.promiseWrap(() => {
       const command = new this.lib.BatchWriteCommand(params);
-      return this.client.send(command);
-    });
+      return this.client.send(command, { abortSignal: options.abortSignal });
+    }, options.abortSignal);
   }
-  batchGet(params) {
-    return this.promiseWrap(async () => {
+  batchGet(params, options = {}) {
+    return this.promiseWrap(() => {
       const command = new this.lib.BatchGetCommand(params);
-      return this.client.send(command);
-    });
+      return this.client.send(command, { abortSignal: options.abortSignal });
+    }, options.abortSignal);
   }
-  scan(params) {
-    return this.promiseWrap(async () => {
+  scan(params, options = {}) {
+    return this.promiseWrap(() => {
       const command = new this.lib.ScanCommand(params);
-      return this.client.send(command);
-    });
+      return this.client.send(command, { abortSignal: options.abortSignal });
+    }, options.abortSignal);
   }
-  query(params) {
-    return this.promiseWrap(async () => {
+  query(params, options = {}) {
+    return this.promiseWrap(() => {
       const command = new this.lib.QueryCommand(params);
-      return this.client.send(command);
-    });
+      return this.client.send(command, { abortSignal: options.abortSignal });
+    }, options.abortSignal);
   }
 
-  transactWrite(params) {
-    return this.promiseWrap(async () => {
+  transactWrite(params, options = {}) {
+    return this.promiseWrap(() => {
       const command = new this.lib.TransactWriteCommand(params);
       return this.client
-        .send(command)
+        .send(command, { abortSignal: options.abortSignal })
         .then((result) => {
           return result;
         })
@@ -220,13 +334,13 @@ class DocumentClientV3Wrapper {
           }
           throw err;
         });
-    });
+    }, options.abortSignal);
   }
-  transactGet(params) {
-    return this.promiseWrap(async () => {
+  transactGet(params, options = {}) {
+    return this.promiseWrap(() => {
       const command = new this.lib.TransactGetCommand(params);
       return this.client
-        .send(command)
+        .send(command, { abortSignal: options.abortSignal })
         .then((result) => {
           return result;
         })
@@ -243,7 +357,7 @@ class DocumentClientV3Wrapper {
           }
           throw err;
         });
-    });
+    }, options.abortSignal);
   }
   createSet(value) {
     if (Array.isArray(value)) {

--- a/src/client.js
+++ b/src/client.js
@@ -247,12 +247,7 @@ class DocumentClientV3Wrapper {
         try {
           return await fn();
         } catch (err) {
-          if (
-            !!err &&
-            typeof err === "object" &&
-            err.name === "AbortError" ||
-            (signal && signal.aborted)
-          ) {
+          if (signal && signal.aborted) {
             throw new ElectroError(
               ErrorCodes.OperationAborted,
               "The operation was aborted",

--- a/src/client.js
+++ b/src/client.js
@@ -49,12 +49,11 @@ class DocumentClientV2Wrapper {
     this.__v = "v2";
   }
 
-  _wrapRequest(request, signal) {
+  _wrapRequest(makeRequest, signal) {
     return {
       promise: () => {
         return new Promise((resolve, reject) => {
           if (signal && signal.aborted) {
-            request.abort();
             return reject(
               new ElectroError(
                 ErrorCodes.OperationAborted,
@@ -62,6 +61,8 @@ class DocumentClientV2Wrapper {
               ),
             );
           }
+
+          const request = makeRequest();
 
           const onAbort = () => {
             request.abort();
@@ -97,60 +98,42 @@ class DocumentClientV2Wrapper {
   }
 
   get(params, options = {}) {
-    const request = this.client.get(params);
-    return this._wrapRequest(request, options.abortSignal);
+    return this._wrapRequest(() => this.client.get(params), options.abortSignal);
   }
 
   put(params, options = {}) {
-    const request = this.client.put(params);
-    return this._wrapRequest(request, options.abortSignal);
+    return this._wrapRequest(() => this.client.put(params), options.abortSignal);
   }
 
   update(params, options = {}) {
-    const request = this.client.update(params);
-    return this._wrapRequest(request, options.abortSignal);
+    return this._wrapRequest(() => this.client.update(params), options.abortSignal);
   }
 
   delete(params, options = {}) {
-    const request = this.client.delete(params);
-    return this._wrapRequest(request, options.abortSignal);
+    return this._wrapRequest(() => this.client.delete(params), options.abortSignal);
   }
 
   batchWrite(params, options = {}) {
-    const request = this.client.batchWrite(params);
-    return this._wrapRequest(request, options.abortSignal);
+    return this._wrapRequest(() => this.client.batchWrite(params), options.abortSignal);
   }
 
   batchGet(params, options = {}) {
-    const request = this.client.batchGet(params);
-    return this._wrapRequest(request, options.abortSignal);
+    return this._wrapRequest(() => this.client.batchGet(params), options.abortSignal);
   }
 
   scan(params, options = {}) {
-    const request = this.client.scan(params);
-    return this._wrapRequest(request, options.abortSignal);
+    return this._wrapRequest(() => this.client.scan(params), options.abortSignal);
   }
 
   query(params, options = {}) {
-    const request = this.client.query(params);
-    return this._wrapRequest(request, options.abortSignal);
+    return this._wrapRequest(() => this.client.query(params), options.abortSignal);
   }
 
-  _transact(transactionRequest, signal) {
-    let cancellationReasons;
-    transactionRequest.on("extractError", (response) => {
-      try {
-        cancellationReasons = JSON.parse(
-          response.httpResponse.body.toString(),
-        ).CancellationReasons;
-      } catch (err) {}
-    });
-
+  _transact(makeTransactionRequest, signal) {
     return {
       promise: () => {
         return new Promise((resolve, reject) => {
           if (signal && signal.aborted) {
-            transactionRequest.abort();
             return reject(
               new ElectroError(
                 ErrorCodes.OperationAborted,
@@ -158,6 +141,16 @@ class DocumentClientV2Wrapper {
               ),
             );
           }
+
+          const transactionRequest = makeTransactionRequest();
+          let cancellationReasons;
+          transactionRequest.on("extractError", (response) => {
+            try {
+              cancellationReasons = JSON.parse(
+                response.httpResponse.body.toString(),
+              ).CancellationReasons;
+            } catch (err) {}
+          });
 
           const onAbort = () => {
             transactionRequest.abort();
@@ -206,13 +199,11 @@ class DocumentClientV2Wrapper {
   }
 
   transactWrite(params, options = {}) {
-    const transactionRequest = this.client.transactWrite(params);
-    return this._transact(transactionRequest, options.abortSignal);
+    return this._transact(() => this.client.transactWrite(params), options.abortSignal);
   }
 
   transactGet(params, options = {}) {
-    const transactionRequest = this.client.transactGet(params);
-    return this._transact(transactionRequest, options.abortSignal);
+    return this._transact(() => this.client.transactGet(params), options.abortSignal);
   }
 
   createSet(value, ...rest) {

--- a/src/entity.js
+++ b/src/entity.js
@@ -1962,6 +1962,12 @@ class Entity {
       }
 
       if (option.abortSignal !== undefined) {
+        if (!validations.isAbortSignal(option.abortSignal)) {
+          throw new e.ElectroError(
+            e.ErrorCodes.InvalidOptions,
+            "Invalid 'abortSignal' option provided. Expected an AbortSignal-like object with an 'aborted' boolean and 'addEventListener'/'removeEventListener' methods.",
+          );
+        }
         config.abortSignal = option.abortSignal;
       }
 

--- a/src/entity.js
+++ b/src/entity.js
@@ -517,7 +517,8 @@ class Entity {
     };
     const dynamoDBMethod = MethodTypeTranslation[method];
     const client = config.client || this.client;
-    return client[dynamoDBMethod](params)
+    const clientOptions = { abortSignal: config.abortSignal };
+    return client[dynamoDBMethod](params, clientOptions)
       .promise()
       .then((results) => {
         notifyQuery();
@@ -531,7 +532,10 @@ class Entity {
           enumerable: false,
           value: params,
         });
-        err.__isAWSError = true;
+        // Only mark as AWS error if it's not already an ElectroError
+        if (!err.isElectroError) {
+          err.__isAWSError = true;
+        }
         throw err;
       });
   }
@@ -544,6 +548,12 @@ class Entity {
     let concurrent = this._normalizeConcurrencyValue(config.concurrent);
     let concurrentOperations = u.batchItems(parameters, concurrent);
     for (let operation of concurrentOperations) {
+      if (config.abortSignal && config.abortSignal.aborted) {
+        throw new e.ElectroError(
+          e.ErrorCodes.OperationAborted,
+          "The operation was aborted",
+        );
+      }
       await Promise.all(
         operation.map(async (params) => {
           let response = await this._exec(
@@ -619,6 +629,12 @@ class Entity {
       : [];
     let unprocessedAll = [];
     for (let operation of concurrentOperations) {
+      if (config.abortSignal && config.abortSignal.aborted) {
+        throw new e.ElectroError(
+          e.ErrorCodes.OperationAborted,
+          "The operation was aborted",
+        );
+      }
       await Promise.all(
         operation.map(async (params) => {
           let response = await this._exec(MethodTypes.batchGet, params, config);
@@ -701,6 +717,12 @@ class Entity {
       config.hydrate &&
       (method === MethodTypes.query || method === MethodTypes.scan);
     do {
+      if (config.abortSignal && config.abortSignal.aborted) {
+        throw new e.ElectroError(
+          e.ErrorCodes.OperationAborted,
+          "The operation was aborted",
+        );
+      }
       let response = await this._exec(
         method,
         { ExclusiveStartKey, ...parameters },
@@ -1682,6 +1704,7 @@ class Entity {
       hydrator: (_entity, _indexName, items) => items,
       _objectOnEmpty: false,
       _includeOnResponseItem: {},
+      abortSignal: undefined,
     };
 
     // Auto-set ignoreOwnership: true for INCLUDE or KEYS_ONLY indexes
@@ -1936,6 +1959,10 @@ class Entity {
 
       if (option.client !== undefined) {
         config.client = c.normalizeClient(option.client);
+      }
+
+      if (option.abortSignal !== undefined) {
+        config.abortSignal = option.abortSignal;
       }
 
       if (option._includeOnResponseItem) {

--- a/src/errors.js
+++ b/src/errors.js
@@ -259,6 +259,12 @@ const ErrorCodes = {
     name: "AWSError",
     sym: ErrorCode,
   },
+  OperationAborted: {
+    code: 4002,
+    section: "operation-aborted",
+    name: "OperationAborted",
+    sym: ErrorCode,
+  },
   UnknownError: {
     code: 5001,
     section: "unknown-error",

--- a/src/validations.js
+++ b/src/validations.js
@@ -371,6 +371,16 @@ function isFunction(value) {
   return typeof value === "function";
 }
 
+function isAbortSignal(value) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof value.aborted === "boolean" &&
+    typeof value.addEventListener === "function" &&
+    typeof value.removeEventListener === "function"
+  );
+}
+
 function stringArrayMatch(arr1, arr2) {
   let areArrays = Array.isArray(arr1) && Array.isArray(arr2);
   let match = areArrays && arr1.length === arr2.length;
@@ -418,6 +428,7 @@ function isMatchingProjection(received, expected) {
 module.exports = {
   testModel,
   isFunction,
+  isAbortSignal,
   stringArrayMatch,
   isMatchingProjection,
   isMatchingCasing,

--- a/test/offline.abort.spec.js
+++ b/test/offline.abort.spec.js
@@ -681,31 +681,6 @@ describe("AbortSignal Support", () => {
   });
 
   describe("V3 wrapper AbortError conversion", () => {
-    it("should convert AWS SDK AbortError thrown during execution to ElectroError", async () => {
-      // Create a mock V3 wrapper to test the promiseWrap error conversion
-      const { DocumentClientV3Wrapper } = c;
-      const mockLib = {};
-      const mockClient = {};
-      const wrapper = new DocumentClientV3Wrapper(mockClient, mockLib);
-
-      // Simulate AWS SDK v3 throwing an AbortError during execution
-      const abortError = new Error("The operation was aborted.");
-      abortError.name = "AbortError";
-
-      const signal = { aborted: false };
-      const wrappedFn = wrapper.promiseWrap(() => {
-        throw abortError;
-      }, signal);
-
-      try {
-        await wrappedFn.promise();
-        expect.fail("Should have thrown an error");
-      } catch (err) {
-        expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
-        expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
-      }
-    });
-
     it("should convert error to ElectroError when signal becomes aborted during execution", async () => {
       const { DocumentClientV3Wrapper } = c;
       const mockLib = {};

--- a/test/offline.abort.spec.js
+++ b/test/offline.abort.spec.js
@@ -1,0 +1,756 @@
+process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = "1";
+const { expect } = require("chai");
+const { Entity, Service } = require("../");
+const { v4: uuid } = require("uuid");
+const { DocumentClient: V2Client } = require("aws-sdk/clients/dynamodb");
+const { DynamoDBClient: V3Client } = require("@aws-sdk/client-dynamodb");
+
+const c = require("../src/client");
+const { ErrorCodes } = require("../src/errors");
+
+const table = "electro";
+
+const v2Client = new V2Client({
+  region: "us-east-1",
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
+});
+
+const v3Client = new V3Client({
+  region: "us-east-1",
+  endpoint: process.env.LOCAL_DYNAMO_ENDPOINT ?? "http://localhost:8000",
+  credentials: {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+  },
+});
+
+const clients = [
+  ["v2", v2Client],
+  ["v3", v3Client],
+];
+
+function createEntity(client) {
+  return new Entity(
+    {
+      model: {
+        entity: uuid(),
+        service: "abort-test",
+        version: "1",
+      },
+      attributes: {
+        prop1: {
+          type: "string",
+        },
+        prop2: {
+          type: "string",
+        },
+        prop3: {
+          type: "string",
+        },
+      },
+      indexes: {
+        record: {
+          pk: {
+            field: "pk",
+            composite: ["prop1"],
+          },
+          sk: {
+            field: "sk",
+            composite: ["prop2"],
+          },
+        },
+      },
+    },
+    { table, client },
+  );
+}
+
+function createEntityWithGSI(client) {
+  return new Entity(
+    {
+      model: {
+        entity: uuid(),
+        service: "abort-test",
+        version: "1",
+      },
+      attributes: {
+        prop1: {
+          type: "string",
+        },
+        prop2: {
+          type: "string",
+        },
+        prop3: {
+          type: "string",
+        },
+      },
+      indexes: {
+        record: {
+          pk: {
+            field: "pk",
+            composite: ["prop1"],
+          },
+          sk: {
+            field: "sk",
+            composite: ["prop2"],
+          },
+        },
+        byProp3: {
+          index: "gsi1pk-gsi1sk-index",
+          pk: {
+            field: "gsi1pk",
+            composite: ["prop3"],
+          },
+          sk: {
+            field: "gsi1sk",
+            composite: ["prop1"],
+          },
+        },
+      },
+    },
+    { table, client },
+  );
+}
+
+function createService(client) {
+  const entity = new Entity(
+    {
+      model: {
+        entity: uuid(),
+        service: "abort-service-test",
+        version: "1",
+      },
+      attributes: {
+        prop1: {
+          type: "string",
+        },
+        prop2: {
+          type: "string",
+        },
+        prop3: {
+          type: "string",
+        },
+      },
+      indexes: {
+        record: {
+          pk: {
+            field: "pk",
+            composite: ["prop1"],
+          },
+          sk: {
+            field: "sk",
+            composite: ["prop2"],
+          },
+        },
+      },
+    },
+    { table, client },
+  );
+
+  return new Service({ entity }, { table, client });
+}
+
+describe("AbortSignal Support", () => {
+  for (const [version, client] of clients) {
+    describe(`${version} client`, () => {
+      describe("Single Operations", () => {
+        it("should abort a get operation when signal is already aborted", async () => {
+          const entity = createEntity(client);
+          const controller = new AbortController();
+          controller.abort();
+
+          try {
+            await entity
+              .get({ prop1: "value1", prop2: "value2" })
+              .go({ abortSignal: controller.signal });
+            expect.fail("Should have thrown an error");
+          } catch (err) {
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+          }
+        });
+
+        it("should complete a get operation when signal is not aborted", async () => {
+          const entity = createEntity(client);
+          const prop1 = uuid();
+          const prop2 = uuid();
+
+          await entity.put({ prop1, prop2, prop3: "test" }).go();
+
+          const controller = new AbortController();
+          const result = await entity
+            .get({ prop1, prop2 })
+            .go({ abortSignal: controller.signal });
+
+          expect(result.data).to.not.be.null;
+          expect(result.data.prop1).to.equal(prop1);
+        });
+
+        it("should abort a put operation when signal is already aborted", async () => {
+          const entity = createEntity(client);
+          const controller = new AbortController();
+          controller.abort();
+
+          try {
+            await entity
+              .put({ prop1: "value1", prop2: "value2" })
+              .go({ abortSignal: controller.signal });
+            expect.fail("Should have thrown an error");
+          } catch (err) {
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+          }
+        });
+
+        it("should abort an update operation when signal is already aborted", async () => {
+          const entity = createEntity(client);
+          const controller = new AbortController();
+          controller.abort();
+
+          try {
+            await entity
+              .update({ prop1: "value1", prop2: "value2" })
+              .set({ prop3: "value3" })
+              .go({ abortSignal: controller.signal });
+            expect.fail("Should have thrown an error");
+          } catch (err) {
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+          }
+        });
+
+        it("should abort a delete operation when signal is already aborted", async () => {
+          const entity = createEntity(client);
+          const controller = new AbortController();
+          controller.abort();
+
+          try {
+            await entity
+              .delete({ prop1: "value1", prop2: "value2" })
+              .go({ abortSignal: controller.signal });
+            expect.fail("Should have thrown an error");
+          } catch (err) {
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+          }
+        });
+      });
+
+      describe("Query Operations", () => {
+        it("should abort a query operation when signal is already aborted", async () => {
+          const entity = createEntity(client);
+          const controller = new AbortController();
+          controller.abort();
+
+          try {
+            await entity.query
+              .record({ prop1: "value1" })
+              .go({ abortSignal: controller.signal });
+            expect.fail("Should have thrown an error");
+          } catch (err) {
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+          }
+        });
+
+        it("should complete a query operation when signal is not aborted", async () => {
+          const entity = createEntity(client);
+          const prop1 = uuid();
+
+          await entity.put({ prop1, prop2: "a", prop3: "test1" }).go();
+          await entity.put({ prop1, prop2: "b", prop3: "test2" }).go();
+
+          const controller = new AbortController();
+          const result = await entity.query
+            .record({ prop1 })
+            .go({ abortSignal: controller.signal });
+
+          expect(result.data).to.be.an("array");
+          expect(result.data.length).to.equal(2);
+        });
+
+        it("should abort a scan operation when signal is already aborted", async () => {
+          const entity = createEntity(client);
+          const controller = new AbortController();
+          controller.abort();
+
+          try {
+            await entity.scan.go({ abortSignal: controller.signal });
+            expect.fail("Should have thrown an error");
+          } catch (err) {
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+          }
+        });
+      });
+
+      describe("Batch Operations", () => {
+        it("should abort a batch get operation when signal is already aborted", async () => {
+          const entity = createEntity(client);
+          const controller = new AbortController();
+          controller.abort();
+
+          try {
+            await entity
+              .get([
+                { prop1: "value1", prop2: "value2" },
+                { prop1: "value3", prop2: "value4" },
+              ])
+              .go({ abortSignal: controller.signal });
+            expect.fail("Should have thrown an error");
+          } catch (err) {
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+          }
+        });
+
+        it("should complete a batch get operation when signal is not aborted", async () => {
+          const entity = createEntity(client);
+          const prop1 = uuid();
+
+          await entity.put({ prop1, prop2: "a", prop3: "test1" }).go();
+          await entity.put({ prop1, prop2: "b", prop3: "test2" }).go();
+
+          const controller = new AbortController();
+          const result = await entity
+            .get([
+              { prop1, prop2: "a" },
+              { prop1, prop2: "b" },
+            ])
+            .go({ abortSignal: controller.signal });
+
+          expect(result.data).to.be.an("array");
+          expect(result.data.length).to.equal(2);
+        });
+
+        it("should abort a batch put operation when signal is already aborted", async () => {
+          const entity = createEntity(client);
+          const controller = new AbortController();
+          controller.abort();
+
+          try {
+            await entity
+              .put([
+                { prop1: "value1", prop2: "value2" },
+                { prop1: "value3", prop2: "value4" },
+              ])
+              .go({ abortSignal: controller.signal });
+            expect.fail("Should have thrown an error");
+          } catch (err) {
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+          }
+        });
+
+        it("should abort a batch delete operation when signal is already aborted", async () => {
+          const entity = createEntity(client);
+          const controller = new AbortController();
+          controller.abort();
+
+          try {
+            await entity
+              .delete([
+                { prop1: "value1", prop2: "value2" },
+                { prop1: "value3", prop2: "value4" },
+              ])
+              .go({ abortSignal: controller.signal });
+            expect.fail("Should have thrown an error");
+          } catch (err) {
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+          }
+        });
+      });
+
+      describe("Transaction Operations", () => {
+        it("should abort a transaction write when signal is already aborted", async () => {
+          const service = createService(client);
+          const controller = new AbortController();
+          controller.abort();
+
+          try {
+            await service.transaction
+              .write(({ entity }) => [
+                entity.put({ prop1: uuid(), prop2: uuid() }).commit(),
+              ])
+              .go({ abortSignal: controller.signal });
+            expect.fail("Should have thrown an error");
+          } catch (err) {
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+          }
+        });
+
+        it("should abort a transaction get when signal is already aborted", async () => {
+          const service = createService(client);
+          const controller = new AbortController();
+          controller.abort();
+
+          try {
+            await service.transaction
+              .get(({ entity }) => [
+                entity.get({ prop1: "value1", prop2: "value2" }).commit(),
+              ])
+              .go({ abortSignal: controller.signal });
+            expect.fail("Should have thrown an error");
+          } catch (err) {
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+          }
+        });
+
+        it("should complete a transaction write when signal is not aborted", async () => {
+          const service = createService(client);
+          const controller = new AbortController();
+          const prop1 = uuid();
+          const prop2 = uuid();
+
+          const result = await service.transaction
+            .write(({ entity }) => [
+              entity.put({ prop1, prop2, prop3: "test" }).commit(),
+            ])
+            .go({ abortSignal: controller.signal });
+
+          expect(result.canceled).to.be.false;
+        });
+      });
+    });
+  }
+
+  describe("Abort during execution", () => {
+    for (const [version, client] of clients) {
+      describe(`${version} client - abort mid-execution`, () => {
+        it("should abort a query operation mid-execution", async () => {
+          const entity = createEntity(client);
+          const prop1 = uuid();
+
+          for (let i = 0; i < 5; i++) {
+            await entity
+              .put({ prop1, prop2: `value${i}`, prop3: `test${i}` })
+              .go();
+          }
+
+          try {
+            await entity.query.record({ prop1 }).go({
+              abortSignal: AbortSignal.timeout(5),
+              pages: "all",
+            });
+            // Query may complete before timeout triggers - this is acceptable
+          } catch (err) {
+            // If aborted, verify error code is correct
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+          }
+        });
+      });
+    }
+  });
+
+  describe("Loop abort checks", () => {
+    for (const [version, client] of clients) {
+      describe(`${version} client - loop abort checks`, () => {
+        it("should check abort signal before each page in executeQuery", async () => {
+          const entity = createEntity(client);
+          const controller = new AbortController();
+          const prop1 = uuid();
+
+          const items = [];
+          for (let i = 0; i < 10; i++) {
+            items.push({ prop1, prop2: `value${i}`, prop3: `test${i}` });
+          }
+          await entity.put(items).go();
+
+          controller.abort();
+
+          try {
+            await entity.query.record({ prop1 }).go({
+              abortSignal: controller.signal,
+              pages: "all",
+              limit: 1,
+            });
+            expect.fail("Should have thrown an error");
+          } catch (err) {
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+          }
+        });
+
+        it("should check abort signal before each batch in executeBulkGet", async () => {
+          const entity = createEntity(client);
+          const controller = new AbortController();
+          const prop1 = uuid();
+
+          const items = [];
+          for (let i = 0; i < 5; i++) {
+            items.push({ prop1, prop2: `value${i}`, prop3: `test${i}` });
+          }
+          await entity.put(items).go();
+
+          controller.abort();
+
+          const keys = items.map((item) => ({ prop1, prop2: item.prop2 }));
+
+          try {
+            await entity.get(keys).go({
+              abortSignal: controller.signal,
+            });
+            expect.fail("Should have thrown an error");
+          } catch (err) {
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+          }
+        });
+
+        it("should check abort signal before each batch in executeBulkWrite", async () => {
+          const entity = createEntity(client);
+          const controller = new AbortController();
+          const prop1 = uuid();
+
+          controller.abort();
+
+          const items = [];
+          for (let i = 0; i < 5; i++) {
+            items.push({ prop1, prop2: `value${i}`, prop3: `test${i}` });
+          }
+
+          try {
+            await entity.put(items).go({
+              abortSignal: controller.signal,
+            });
+            expect.fail("Should have thrown an error");
+          } catch (err) {
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+          }
+        });
+      });
+    }
+  });
+
+  describe("Abort between requests", () => {
+    for (const [version, client] of clients) {
+      describe(`${version} client - abort between requests`, () => {
+        it("should abort paginated query after first page", async () => {
+          const entity = createEntity(client);
+          const controller = new AbortController();
+          const prop1 = uuid();
+
+          const items = [];
+          for (let i = 0; i < 10; i++) {
+            items.push({ prop1, prop2: `value${String(i).padStart(2, "0")}`, prop3: `test${i}` });
+          }
+          await entity.put(items).go();
+
+          let requestCount = 0;
+          const logger = (event) => {
+            if (event.type === "query") {
+              requestCount++;
+              if (requestCount === 1) {
+                controller.abort();
+              }
+            }
+          };
+
+          try {
+            await entity.query.record({ prop1 }).go({
+              abortSignal: controller.signal,
+              pages: "all",
+              limit: 2,
+              logger,
+            });
+            expect.fail("Should have thrown an error");
+          } catch (err) {
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+            expect(requestCount).to.equal(1);
+          }
+        });
+
+        it("should abort bulk get after first batch when using concurrent: 1", async () => {
+          const entity = createEntity(client);
+          const controller = new AbortController();
+          const prop1 = uuid();
+
+          const items = [];
+          for (let i = 0; i < 150; i++) {
+            items.push({ prop1, prop2: `value${i}`, prop3: `test${i}` });
+          }
+          await entity.put(items).go();
+
+          let requestCount = 0;
+          const logger = (event) => {
+            if (event.type === "query") {
+              requestCount++;
+              if (requestCount === 1) {
+                controller.abort();
+              }
+            }
+          };
+
+          const keys = items.map((item) => ({ prop1, prop2: item.prop2 }));
+
+          try {
+            await entity.get(keys).go({
+              abortSignal: controller.signal,
+              concurrent: 1,
+              logger,
+            });
+            expect.fail("Should have thrown an error");
+          } catch (err) {
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+            expect(requestCount).to.equal(1);
+          }
+        });
+
+        it("should abort bulk write after first batch when using concurrent: 1", async () => {
+          const entity = createEntity(client);
+          const controller = new AbortController();
+          const prop1 = uuid();
+
+          let requestCount = 0;
+          const logger = (event) => {
+            if (event.type === "query") {
+              requestCount++;
+              if (requestCount === 1) {
+                controller.abort();
+              }
+            }
+          };
+
+          const items = [];
+          for (let i = 0; i < 50; i++) {
+            items.push({ prop1, prop2: `value${i}`, prop3: `test${i}` });
+          }
+
+          try {
+            await entity.put(items).go({
+              abortSignal: controller.signal,
+              concurrent: 1,
+              logger,
+            });
+            expect.fail("Should have thrown an error");
+          } catch (err) {
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+            expect(requestCount).to.equal(1);
+          }
+        });
+
+        it("should abort hydrate query after initial query but before batch get", async () => {
+          const entity = createEntityWithGSI(client);
+          const controller = new AbortController();
+          const prop1 = uuid();
+          const prop3 = uuid();
+
+          const items = [];
+          for (let i = 0; i < 5; i++) {
+            items.push({ prop1: `${prop1}_${i}`, prop2: `value${i}`, prop3 });
+          }
+          await entity.put(items).go();
+
+          let requestCount = 0;
+          const logger = (event) => {
+            if (event.type === "query") {
+              requestCount++;
+              if (requestCount === 1) {
+                controller.abort();
+              }
+            }
+          };
+
+          try {
+            await entity.query.byProp3({ prop3 }).go({
+              abortSignal: controller.signal,
+              hydrate: true,
+              logger,
+            });
+            expect.fail("Should have thrown an error");
+          } catch (err) {
+            expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+            expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+            expect(requestCount).to.equal(1);
+          }
+        });
+      });
+    }
+  });
+
+  describe("V3 wrapper AbortError conversion", () => {
+    it("should convert AWS SDK AbortError thrown during execution to ElectroError", async () => {
+      // Create a mock V3 wrapper to test the promiseWrap error conversion
+      const { DocumentClientV3Wrapper } = c;
+      const mockLib = {};
+      const mockClient = {};
+      const wrapper = new DocumentClientV3Wrapper(mockClient, mockLib);
+
+      // Simulate AWS SDK v3 throwing an AbortError during execution
+      const abortError = new Error("The operation was aborted.");
+      abortError.name = "AbortError";
+
+      const signal = { aborted: false };
+      const wrappedFn = wrapper.promiseWrap(() => {
+        throw abortError;
+      }, signal);
+
+      try {
+        await wrappedFn.promise();
+        expect.fail("Should have thrown an error");
+      } catch (err) {
+        expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+        expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+      }
+    });
+
+    it("should convert error to ElectroError when signal becomes aborted during execution", async () => {
+      const { DocumentClientV3Wrapper } = c;
+      const mockLib = {};
+      const mockClient = {};
+      const wrapper = new DocumentClientV3Wrapper(mockClient, mockLib);
+
+      // Simulate a generic error thrown while signal is aborted
+      const genericError = new Error("Some network error");
+      const signal = { aborted: false };
+
+      const wrappedFn = wrapper.promiseWrap(() => {
+        // Signal becomes aborted during execution
+        signal.aborted = true;
+        throw genericError;
+      }, signal);
+
+      try {
+        await wrappedFn.promise();
+        expect.fail("Should have thrown an error");
+      } catch (err) {
+        expect(err.message).to.equal("The operation was aborted - For more detail on this error reference: https://electrodb.dev/en/reference/errors/#operation-aborted");
+        expect(err.code).to.equal(ErrorCodes.OperationAborted.code);
+      }
+    });
+
+    it("should not convert non-abort errors when signal is not aborted", async () => {
+      const { DocumentClientV3Wrapper } = c;
+      const mockLib = {};
+      const mockClient = {};
+      const wrapper = new DocumentClientV3Wrapper(mockClient, mockLib);
+
+      const genericError = new Error("Some other error");
+      const signal = { aborted: false };
+
+      const wrappedFn = wrapper.promiseWrap(() => {
+        throw genericError;
+      }, signal);
+
+      try {
+        await wrappedFn.promise();
+        expect.fail("Should have thrown an error");
+      } catch (err) {
+        expect(err.message).to.equal("Some other error");
+        expect(err.code).to.be.undefined;
+      }
+    });
+  });
+});

--- a/test/offline.abort.spec.js
+++ b/test/offline.abort.spec.js
@@ -728,4 +728,64 @@ describe("AbortSignal Support", () => {
       }
     });
   });
+
+  describe("abortSignal option validation", () => {
+    const entity = createEntity(v3Client);
+    const invalidValues = [
+      ["string", "not-a-signal"],
+      ["number", 42],
+      ["boolean", true],
+      ["null", null],
+      ["plain object", {}],
+      ["object missing addEventListener", {
+        aborted: false,
+        removeEventListener: () => {},
+      }],
+      ["object missing removeEventListener", {
+        aborted: false,
+        addEventListener: () => {},
+      }],
+      ["object with non-boolean aborted", {
+        aborted: "yes",
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      }],
+    ];
+
+    for (const [label, value] of invalidValues) {
+      it(`should reject invalid abortSignal (${label})`, async () => {
+        try {
+          await entity
+            .get({ prop1: "value1", prop2: "value2" })
+            .go({ abortSignal: value });
+          expect.fail("Should have thrown an error");
+        } catch (err) {
+          expect(err.code).to.equal(ErrorCodes.InvalidOptions.code);
+          expect(err.message).to.include("abortSignal");
+        }
+      });
+    }
+
+    it("should accept a real AbortSignal", () => {
+      const controller = new AbortController();
+      expect(() =>
+        entity
+          .get({ prop1: "value1", prop2: "value2" })
+          .params({ abortSignal: controller.signal }),
+      ).to.not.throw();
+    });
+
+    it("should accept a duck-typed AbortSignal-like object", () => {
+      const fake = {
+        aborted: false,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      };
+      expect(() =>
+        entity
+          .get({ prop1: "value1", prop2: "value2" })
+          .params({ abortSignal: fake }),
+      ).to.not.throw();
+    });
+  });
 });

--- a/www/src/pages/en/mutations/transact-write.mdx
+++ b/www/src/pages/en/mutations/transact-write.mdx
@@ -322,13 +322,15 @@ By default, **ElectroDB** enables you to work with records as the names and prop
 {
   client?: DocumentClient;
   token?: string;
+  abortSignal?: AbortSignal;
 }
 ```
 
-| Option | Default              | Description                                                                                                                                                                                                                                                                                                             |
-| ------ | :------------------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| client | _(from constructor)_ | Provide a DynamoDB client dynamically at query execution time. This allows per-request client selection without modifying the Entity or Service instance. The client provided here takes precedence over any client set at instantiation time. Both v2 and v3 AWS SDK clients are supported and will be auto-detected. |
-| token  |        _none_        | Adds the provided value as a `ClientRequestToken` along with your request to DynamoDB.                                                                                                                                                                                                                                  |
+| Option      | Default              | Description                                                                                                                                                                                                                                                                                                             |
+| ----------- | :------------------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| client      | _(from constructor)_ | Provide a DynamoDB client dynamically at query execution time. This allows per-request client selection without modifying the Entity or Service instance. The client provided here takes precedence over any client set at instantiation time. Both v2 and v3 AWS SDK clients are supported and will be auto-detected. |
+| token       |        _none_        | Adds the provided value as a `ClientRequestToken` along with your request to DynamoDB.                                                                                                                                                                                                                                  |
+| abortSignal |        _none_        | An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can be used to cancel the operation. This is useful for implementing request timeouts or cancelling long-running operations. When the signal is aborted, ElectroDB will throw an [`OperationAborted`](/en/reference/errors#operation-aborted) error. |
 
 ## Resources
 

--- a/www/src/pages/en/queries/batch-get.mdx
+++ b/www/src/pages/en/queries/batch-get.mdx
@@ -109,6 +109,7 @@ By default, **ElectroDB** enables you to work with records as the names and prop
   preserveBatchOrder?: boolean;
   attributes?: string[];
   consistent?: boolean;
+  abortSignal?: AbortSignal;
 };
 ```
 
@@ -128,3 +129,4 @@ By default, **ElectroDB** enables you to work with records as the names and prop
 | logger             |        _none_        | A convenience option for a single event listener that semantically can be used for logging.                                                                                                                                                                                                                                                                                                   |
 | preserveBatchOrder |       `false`        | When used with a [batchGet](/en/queries/batch-get) operation, ElectroDB will ensure the order returned by a batchGet will be the same as the order provided. When enabled, if a record is returned from DynamoDB as "unprocessed" ([read more here](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html)), ElectroDB will return a null value at that index. |
 | consistent         |        _none_        | When set to `true`, DynamoDB will return the most up-to-date data reflecting updates from all prior write operations using DynamoDB's [`ConsistentRead`](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html#HowItWorks.ReadConsistency.Strongly) parameter. Strongly consistent reads are only supported on tables and local secondary indexes. |
+| abortSignal        |        _none_        | An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can be used to cancel the operation. This is useful for implementing request timeouts or cancelling long-running operations. When the signal is aborted, ElectroDB will throw an [`OperationAborted`](/en/reference/errors#operation-aborted) error.                                                      |

--- a/www/src/pages/en/queries/get.mdx
+++ b/www/src/pages/en/queries/get.mdx
@@ -69,6 +69,7 @@ By default, **ElectroDB** enables you to work with records as the names and prop
   listeners Array<(event) => void>;
   attributes?: string[];
   consistent?: boolean;
+  abortSignal?: AbortSignal;
 };
 ```
 
@@ -85,3 +86,4 @@ By default, **ElectroDB** enables you to work with records as the names and prop
 | listeners       |         `[]`         | An array of callbacks that are invoked when [internal ElectroDB events](/en/reference/events-logging) occur.                                                                                                                                                                                                                                                                                  |
 | logger          |        _none_        | A convenience option for a single event listener that semantically can be used for logging.                                                                                                                                                                                                                                                                                                   |
 | consistent      |        _none_        | When set to `true`, DynamoDB will return the most up-to-date data reflecting updates from all prior write operations using DynamoDB's [`ConsistentRead`](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html#HowItWorks.ReadConsistency.Strongly) parameter. Strongly consistent reads are only supported on tables and local secondary indexes. |
+| abortSignal     |        _none_        | An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can be used to cancel the operation. This is useful for implementing request timeouts or cancelling long-running operations. When the signal is aborted, ElectroDB will throw an [`OperationAborted`](/en/reference/errors#operation-aborted) error.                                                      |

--- a/www/src/pages/en/queries/transact-get.mdx
+++ b/www/src/pages/en/queries/transact-get.mdx
@@ -73,12 +73,14 @@ Execution options can be provided to the `.params()` and `.go()` terminal functi
 ```typescript
 {
   client?: DocumentClient;
+  abortSignal?: AbortSignal;
 }
 ```
 
-| Option | Default              | Description                                                                                                                                                                                                                                                                                                             |
-| ------ | :------------------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| client | _(from constructor)_ | Provide a DynamoDB client dynamically at query execution time. This allows per-request client selection without modifying the Entity or Service instance. The client provided here takes precedence over any client set at instantiation time. Both v2 and v3 AWS SDK clients are supported and will be auto-detected. |
+| Option      | Default              | Description                                                                                                                                                                                                                                                                                                             |
+| ----------- | :------------------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| client      | _(from constructor)_ | Provide a DynamoDB client dynamically at query execution time. This allows per-request client selection without modifying the Entity or Service instance. The client provided here takes precedence over any client set at instantiation time. Both v2 and v3 AWS SDK clients are supported and will be auto-detected. |
+| abortSignal |        _none_        | An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can be used to cancel the operation. This is useful for implementing request timeouts or cancelling long-running operations. When the signal is aborted, ElectroDB will throw an [`OperationAborted`](/en/reference/errors#operation-aborted) error. |
 
 The following are some links to help you understand the mechanics behind DynamoDB Transacts
 

--- a/www/src/pages/en/reference/errors.mdx
+++ b/www/src/pages/en/reference/errors.mdx
@@ -524,6 +524,22 @@ DynamoDB did not like something about your query.
 **What to do about it:**
 By default ElectroDB tries to keep the stack trace close to your code, ideally this can help you identify what might be going on. A tip to help with troubleshooting: use `.params()` to get more insight into how your query is converted to DocClient params.
 
+### Operation Aborted
+
+**Code: 4002**
+
+**Why this occurred:**
+The operation was cancelled via an `AbortSignal` passed to the [Execution Options](/en/core-concepts/executing-queries). This can happen when:
+- The `AbortController.abort()` method was called before or during the operation
+- A timeout triggered the abort signal
+- The signal was already aborted when passed to the operation
+
+**What to do about it:**
+This error is expected behavior when intentionally cancelling operations. If you're seeing this error unexpectedly:
+1. Check that your `AbortController` is not being aborted prematurely
+2. Verify any timeout values are appropriate for your operation
+3. Ensure the signal is not shared unintentionally between operations
+
 ## Unexpected Errors
 
 ### No Owner For Pager

--- a/www/src/partials/batch-mutation-execution-options.mdx
+++ b/www/src/partials/batch-mutation-execution-options.mdx
@@ -16,6 +16,7 @@ By default, **ElectroDB** enables you to work with records as the names and prop
   listeners Array<(event) => void>;
   attributes?: string[];
   consistent?: boolean;
+  abortSignal?: AbortSignal;
 };
 ```
 
@@ -33,3 +34,4 @@ By default, **ElectroDB** enables you to work with records as the names and prop
 | listeners   |         `[]`         | An array of callbacks that are invoked when [internal ElectroDB events](#events) occur.                                                                                                                                                                                                                                                                                                       |
 | logger      |        _none_        | A convenience option for a single event listener that semantically can be used for logging.                                                                                                                                                                                                                                                                                                   |
 | consistent  |        _none_        | When set to `true`, DynamoDB will return the most up-to-date data reflecting updates from all prior write operations using DynamoDB's [`ConsistentRead`](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html#HowItWorks.ReadConsistency.Strongly) parameter. Strongly consistent reads are only supported on tables and local secondary indexes. |
+| abortSignal |        _none_        | An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can be used to cancel the operation. This is useful for implementing request timeouts or cancelling long-running operations. When the signal is aborted, ElectroDB will throw an [`OperationAborted`](/en/reference/errors#operation-aborted) error.                                                      |

--- a/www/src/partials/mutation-query-options.mdx
+++ b/www/src/partials/mutation-query-options.mdx
@@ -17,6 +17,7 @@ By default, **ElectroDB** enables you to work with records as the names and prop
   listeners Array<(event) => void>;
   attributes?: string[];
   consistent?: boolean;
+  abortSignal?: AbortSignal;
 }
 ```
 
@@ -35,3 +36,4 @@ By default, **ElectroDB** enables you to work with records as the names and prop
 | listeners       |         `[]`         | An array of callbacks that are invoked when [internal ElectroDB events](/en/reference/events-logging) occur.                                                                                                                                                                                                                                                                                  |
 | logger          |        _none_        | A convenience option for a single event listener that semantically can be used for logging.                                                                                                                                                                                                                                                                                                   |
 | consistent      |        _none_        | When set to `true`, DynamoDB will return the most up-to-date data reflecting updates from all prior write operations using DynamoDB's [`ConsistentRead`](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html#HowItWorks.ReadConsistency.Strongly) parameter. Strongly consistent reads are only supported on tables and local secondary indexes. |
+| abortSignal     |        _none_        | An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can be used to cancel the operation. This is useful for implementing request timeouts or cancelling long-running operations. When the signal is aborted, ElectroDB will throw an [`OperationAborted`](/en/reference/errors#operation-aborted) error.                                                      |

--- a/www/src/partials/query-options.mdx
+++ b/www/src/partials/query-options.mdx
@@ -22,6 +22,7 @@ By default, **ElectroDB** enables you to work with records as the names and prop
   compare?: 'attributes' | 'keys' | 'v2';
   consistent?: boolean;
   projection?: 'all' | 'keys_only' | string[];
+  abortSignal?: AbortSignal;
 };
 ```
 
@@ -102,3 +103,14 @@ When set to `true`, DynamoDB will return the most up-to-date data reflecting upd
 ### projection
 **Default Value:** 'all'
 The `projection` option maps to the DynamoDB table index definition [Projection](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Projection.html).
+
+### abortSignal
+**Default Value:** _none_
+An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can be used to cancel the operation. This is useful for implementing request timeouts or cancelling long-running operations. When the signal is aborted, ElectroDB will throw an [`OperationAborted`](/en/reference/errors#operation-aborted) error. The `abortSignal` option works with both the AWS SDK v2 and v3 DocumentClient.
+
+```typescript
+// Abort if the operation takes longer than 5 seconds
+const result = await MyEntity.query
+  .myIndex({ id: "123" })
+  .go({ abortSignal: AbortSignal.timeout(5000) });
+```


### PR DESCRIPTION
closes https://github.com/tywalch/electrodb/issues/545