### PR TITLE
fix(#548): invalid ProjectionExpression for entities without a sort key when using attributes option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -624,3 +624,7 @@ All notable changes to this project will be documented in this file. Breaking ch
 ### Added 
 - [Issue #507](https://github.com/tywalch/electrodb/issues/507); You can now scan an index. [See docs](https://electrodb.dev/en/queries/scan/#scanning-an-index) Contribution provided by [@anatolzak](https://github.com/anatolzak)
 - [Issue #508](https://github.com/tywalch/electrodb/issues/508); Added support for INCLUDE projection type in index definitions, allowing selective attribute projection for optimized query performance and cost reduction. [See docs](https://electrodb.dev/en/recipes/include-projection-gsi) Contribution provided by [@anatolzak](https://github.com/anatolzak)
+
+## [3.6.1]
+### Fixed
+- [Issue #548](https://github.com/tywalch/electrodb/issues/548); Fixed invalid `ProjectionExpression` generated for entities without a sort key when using the `attributes` option. An empty string was incorrectly added to `ExpressionAttributeNames`, causing DynamoDB to reject the request.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electrodb",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "electrodb",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/lib-dynamodb": "^3.654.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrodb",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "A library to more easily create and interact with multiple entities and heretical relationships in dynamodb",
   "main": "index.js",
   "scripts": {

--- a/src/entity.js
+++ b/src/entity.js
@@ -2085,7 +2085,7 @@ class Entity {
 
     // Convert all attribute names to their respective "field" names
     let hasTableIndexPk = false;
-    let hasTableIndexSk = this.model.translations.keys[TableIndex].sk === undefined;
+    let hasTableIndexSk = !this.model.translations.keys[TableIndex].sk;
     const attributeFields = new Map();
     for (let [key, name] of Object.entries(parameters.ExpressionAttributeNames || {})) {
       if (key.startsWith("#")) {


### PR DESCRIPTION
closes https://github.com/tywalch/electrodb/issues/548