### PR TITLE
fix: bump jsonchema to resolve url.parse deprecation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/lib-dynamodb": "^3.654.0",
         "@aws-sdk/util-dynamodb": "^3.654.0",
-        "jsonschema": "1.2.7"
+        "jsonschema": "1.5.0"
       },
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.395.0",
@@ -23969,9 +23969,10 @@
       ]
     },
     "node_modules/jsonschema": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.7.tgz",
-      "integrity": "sha512-3dFMg9hmI9LdHag/BRIhMefCfbq1hicvYMy8YhZQorAdzOzWz7NjniSpn39yjpzUAMIWtGyyZuH2KNBloH7ZLw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
+      "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -50158,9 +50159,9 @@
       "dev": true
     },
     "jsonschema": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.7.tgz",
-      "integrity": "sha512-3dFMg9hmI9LdHag/BRIhMefCfbq1hicvYMy8YhZQorAdzOzWz7NjniSpn39yjpzUAMIWtGyyZuH2KNBloH7ZLw=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
+      "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw=="
     },
     "JSONStream": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,6 @@
   "dependencies": {
     "@aws-sdk/lib-dynamodb": "^3.654.0",
     "@aws-sdk/util-dynamodb": "^3.654.0",
-    "jsonschema": "1.2.7"
+    "jsonschema": "1.5.0"
   }
 }

--- a/src/validations.js
+++ b/src/validations.js
@@ -284,10 +284,10 @@ v.addSchema(Modelv1, "/Modelv1");
 
 function validateModel(model = {}) {
   /** start beta/v1 condition **/
-  let betaErrors = v.validate(model, "/ModelBeta").errors;
+  let betaErrors = v.validate(model, ModelBeta).errors;
   if (betaErrors.length) {
     /** end/v1 condition **/
-    let errors = v.validate(model, "/Modelv1").errors;
+    let errors = v.validate(model, Modelv1).errors;
     if (errors.length) {
       throw new e.ElectroError(
         e.ErrorCodes.InvalidModel,


### PR DESCRIPTION
### Summary

Fixes #571.

Node v24 emits a [DEP0169] deprecation warning against consumers of ElectroDB because jsonschema@1.2.7 uses the legacy require('url').parse() API.

Upgrading to jsonschema@1.5.0 removes the url module entirely in favour of the WHATWG URL global, silencing the warning.

### Changes

- package.json — bump jsonschema from 1.2.7 → 1.5.0.
- src/validations.js — pass the ModelBeta / Modelv1 schema objects directly to v.validate() instead of their URI strings ("/ModelBeta" / "/Modelv1").

#### More detail

jsonschema@1.5.0 updated the Validator.prototype.validate() entry point to reject anything that isn't an object or boolean:

```
// jsonschema/lib/validator.js
if ((typeof schema !== 'boolean' && typeof schema !== 'object') || schema === null) {
  throw new SchemaError('Expected `schema` to be an object or boolean');
}
```

### Testing

- npm run test:types
- npm run test:unit
- ./test.sh